### PR TITLE
Feature/pelagos 3297 optimize initial dataset discovery load time

### DIFF
--- a/src/Pelagos/Util/DatasetIndex.php
+++ b/src/Pelagos/Util/DatasetIndex.php
@@ -178,6 +178,10 @@ class DatasetIndex
         $query = new Query();
         $query->setSize(10000);
         $query->setQuery($mainQuery);
+
+        //control of what will be returned
+        $query->setSource(array('id', 'udi', 'title', 'year', 'researchGroup', 'datasetSubmission', 'doi'));
+
         return $query;
     }
 

--- a/src/Pelagos/Util/DatasetIndex.php
+++ b/src/Pelagos/Util/DatasetIndex.php
@@ -180,7 +180,13 @@ class DatasetIndex
         $query->setQuery($mainQuery);
 
         //control of what will be returned
-        $query->setSource(array('id', 'udi', 'title', 'year', 'researchGroup', 'datasetSubmission', 'doi'));
+        $query->setSource(
+            array(
+                'id', 'udi', 'title', 'year', 'researchGroup', 'doi', 'datasetSubmission.authors',
+                'datasetSubmission.datasetFileTransferStatus', 'datasetSubmission.datasetFileUri',
+                'datasetSubmission.datasetFileSize', 'datasetSubmission.restrictions'
+            )
+        );
 
         return $query;
     }


### PR DESCRIPTION
Elastica search result will not return geometry and some other unnecessary fields. 
Note: The geometry will not show up at the moment. This will be addressed in another pull request