### PR TITLE
Feature/pelagos 3319 make show all extents button adapt to infinite scrolls

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Resources/public/css/data-discovery.css
+++ b/src/Pelagos/Bundle/AppBundle/Resources/public/css/data-discovery.css
@@ -43,10 +43,10 @@
     padding: 1px 6px;
 }
 
-#show_all_extents_label {
+#show_extents_label {
     font-weight: normal;
     margin-top: 2px;
-    width: 9em;
+    width: 8em;
     text-align: center;
 }
 
@@ -58,7 +58,7 @@ input.ui-button {
     padding: 0px 6px;
 }
 
-#show_all_extents_checkbox {
+#show_extents_checkbox {
     font-size: 100%;
     vertical-align: middle;
 }

--- a/src/Pelagos/Bundle/AppBundle/Resources/public/js/data-discovery.js
+++ b/src/Pelagos/Bundle/AppBundle/Resources/public/js/data-discovery.js
@@ -50,7 +50,7 @@ $(document).ready(function() {
         $("#clearGeoFilterButton").button("disable");
     });
 
-    $("#show_all_extents_checkbox").button();
+    $("#show_extents_checkbox").button();
     $(".map_button").button();
     // local variable for filter button//
     var filterButton = $("#filter-button");
@@ -170,7 +170,7 @@ function addRows() {
         if (data["geometry"]) {
             $(row).hover(function () {
                 //show geometries on the map on hovering on the row
-                if (!$("#show_all_extents_checkbox").is(":checked")) {
+                if (!$("#show_extents_checkbox").is(":checked")) {
                     for (var i = 0; i < datasetList[activeTabIndex].length; i++) {
                         if (datasetList[activeTabIndex][i]["_source"]["udi"] == $(this).attr("udi")) {
                             myGeoViz.addFeatureFromWKT(datasetList[activeTabIndex][i]["_source"]["geometry"], {"udi": datasetList[activeTabIndex][i]["_source"]["udi"]});
@@ -181,12 +181,12 @@ function addRows() {
                 myGeoViz.highlightFeature("udi", $(this).attr("udi"));
             }, function () {
                 myGeoViz.unhighlightFeature("udi", $(this).attr("udi"));
-                if (!$("#show_all_extents_checkbox").is(":checked")) {
+                if (!$("#show_extents_checkbox").is(":checked")) {
                     myGeoViz.removeAllFeaturesFromMap();
                 }
             });
             //add newly rendered geometry if ShowAllExtents is enabled
-            if ($("#show_all_extents_checkbox").is(":checked")) {
+            if ($("#show_extents_checkbox").is(":checked")) {
                 myGeoViz.addFeatureFromWKT(data["geometry"]);
             }
         }
@@ -331,7 +331,7 @@ function showDatasets(by,id) {
     myGeoViz.removeAllFeaturesFromMap();
 
     //enable this
-    $("#show_all_extents_checkbox").button();
+    $("#show_extents_checkbox").button();
     $("#filter-button").button("disable");
     $("#clear-button").button("disable");
 
@@ -365,7 +365,7 @@ function showDatasets(by,id) {
                         loadData(by, id);
                     }
 
-                    if ($("#show_all_extents_checkbox").is(":checked")) {
+                    if ($("#show_extents_checkbox").is(":checked")) {
                         displayActiveTabExtents();
                     }
                 }
@@ -429,11 +429,11 @@ function displayActiveTabExtents()
 }
 
 function showAllExtents() {
-    if ($("#show_all_extents_checkbox").is(":checked")) {
-        $("#show_all_extents_label").html('<span class="ui-button-text">Hide All Extents</span>');
+    if ($("#show_extents_checkbox").is(":checked")) {
+        $("#show_extents_label").html('<span class="ui-button-text">Hide Extents</span>');
         displayActiveTabExtents();
     } else {
-        $("#show_all_extents_label").html('<span class="ui-button-text">Show All Extents</span>');
+        $("#show_extents_label").html('<span class="ui-button-text">Show Extents</span>');
         $("table.datasets tr td").removeClass("highlight");
         myGeoViz.removeAllFeaturesFromMap();
     }

--- a/src/Pelagos/Bundle/AppBundle/Resources/public/js/data-discovery.js
+++ b/src/Pelagos/Bundle/AppBundle/Resources/public/js/data-discovery.js
@@ -381,7 +381,7 @@ function showDatasets(by,id) {
             });
             if (geo_filter) {
                 $("#clearGeoFilterButton").button("enable");
-             }
+            }
         },
         "error": function(jqXHR, textStatus, errorThrown) {
             alert("Fail: " + textStatus + " " + errorThrown + jqXHR.getResponseHeader());

--- a/src/Pelagos/Bundle/AppBundle/Resources/public/js/data-discovery.js
+++ b/src/Pelagos/Bundle/AppBundle/Resources/public/js/data-discovery.js
@@ -169,11 +169,12 @@ function addRows() {
         $(row).attr("datasetid", dataset["_id"]);
         if (data["geometry"]) {
             $(row).hover(function () {
-
+                //show geometries on the map on hovering on the row
                 if (!$("#show_all_extents_checkbox").is(":checked")) {
                     for (var i = 0; i < datasetList[activeTabIndex].length; i++) {
                         if (datasetList[activeTabIndex][i]["_source"]["udi"] == $(this).attr("udi")) {
                             myGeoViz.addFeatureFromWKT(datasetList[activeTabIndex][i]["_source"]["geometry"], {"udi": datasetList[activeTabIndex][i]["_source"]["udi"]});
+                            break;
                         }
                     }
                 }
@@ -184,6 +185,10 @@ function addRows() {
                     myGeoViz.removeAllFeaturesFromMap();
                 }
             });
+            //add newly rendered geometry if ShowAllExtents is enabled
+            if ($("#show_all_extents_checkbox").is(":checked")) {
+                myGeoViz.addFeatureFromWKT(data["geometry"]);
+            }
         }
 
         var rowContent = createRow(data, row);
@@ -192,6 +197,7 @@ function addRows() {
         $("table.datasets[tabIndex=" + activeTabIndex + "]").append(row);
         //add the data to the data array
         datasetList[activeTabIndex].push(dataset);
+
     });
     //clear buffer
     buffer = [];
@@ -324,7 +330,8 @@ function showDatasets(by,id) {
     datasetList[3] = [];
     myGeoViz.removeAllFeaturesFromMap();
 
-    $("#show_all_extents_checkbox").button("disable");
+    //enable this
+    $("#show_all_extents_checkbox").button();
     $("#filter-button").button("disable");
     $("#clear-button").button("disable");
 
@@ -354,16 +361,12 @@ function showDatasets(by,id) {
             $("#tabs").tabs({
                 activate: function(event, ui) {
                     var activeTabIndex = getActiveTabIndex();
-                    if ($("#show_all_extents_checkbox").is(":checked")) {
-                        myGeoViz.removeAllFeaturesFromMap();
-                        if (datasetList[activeTabIndex]) {
-                            for (var i=0; i<datasetList[activeTabIndex].length; i++) {
-                                myGeoViz.addFeatureFromWKT(datasetList[activeTabIndex][i]["_source"]["geometry"],{"udi":datasetList[activeTabIndex][i]["_source"]["udi"]});
-                            }
-                        }
-                    }
                     if (datasetList[activeTabIndex].length == 0) {
                         loadData(by, id);
+                    }
+
+                    if ($("#show_all_extents_checkbox").is(":checked")) {
+                        displayActiveTabExtents();
                     }
                 }
             });
@@ -411,17 +414,24 @@ function clearAll() {
     applyFilter();
 }
 
-function showAllExtents() {
+//this function adds geometries from rendered data to the map
+function displayActiveTabExtents()
+{
+    myGeoViz.removeAllFeaturesFromMap();
     var activeTabIndex = getActiveTabIndex();
-    if ($("#show_all_extents_checkbox").is(":checked")) {
-        $("#show_all_extents_label").html('<span class="ui-button-text">Hide All Extents</span>');
-        var selectedTab = $("#tabs").tabs("option","active");
-        myGeoViz.removeAllFeaturesFromMap();
-        if (datasetList[activeTabIndex]) {
-            for (var i=0; i<datasetList[activeTabIndex].length; i++) {
-                myGeoViz.addFeatureFromWKT(datasetList[activeTabIndex][i]["_source"]["geometry"],{"udi":datasetList[activeTabIndex][i]["_source"]["udi"]});
+    if (datasetList[activeTabIndex]) {
+        for (var i=0; i<datasetList[activeTabIndex].length; i++) {
+            if (datasetList[activeTabIndex][i]["_source"]["geometry"]) {
+                myGeoViz.addFeatureFromWKT(datasetList[activeTabIndex][i]["_source"]["geometry"], {"udi": datasetList[activeTabIndex][i]["_source"]["udi"]});
             }
         }
+    }
+}
+
+function showAllExtents() {
+    if ($("#show_all_extents_checkbox").is(":checked")) {
+        $("#show_all_extents_label").html('<span class="ui-button-text">Hide All Extents</span>');
+        displayActiveTabExtents();
     } else {
         $("#show_all_extents_label").html('<span class="ui-button-text">Show All Extents</span>');
         $("table.datasets tr td").removeClass("highlight");

--- a/src/Pelagos/Bundle/AppBundle/Resources/views/DataDiscovery/index.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/DataDiscovery/index.html.twig
@@ -55,8 +55,8 @@
                     <div id="olmap"></div>
                     <div id="map_buttons">
                         <div class="map_button_container">
-                            <label for="show_all_extents_checkbox" id="show_all_extents_label">Show All Extents</label>
-                            <input type="checkbox" id="show_all_extents_checkbox" class="map_button" onclick="showAllExtents();">
+                            <label for="show_extents_checkbox" id="show_extents_label">Show Extents</label>
+                            <input type="checkbox" id="show_extents_checkbox" class="map_button" onclick="showAllExtents();">
                         </div>
                         <div class="map_button_container">
                             <input type="button" id="clearGeoFilterButton" class="map_button" value="Clear Filter" disabled onclick="$(this).button('disable');myGeoViz.clearFilter();trees['tree'].geo_filter = null;applyFilter();">


### PR DESCRIPTION
Populate currently displayed datasets' geometries on the Show All Extents button