### PR TITLE
feature/PELAGOS-3330-fix-undefined-geometries-in-show-extends-mode-on-switching-tab 

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Resources/public/js/data-discovery.js
+++ b/src/Pelagos/Bundle/AppBundle/Resources/public/js/data-discovery.js
@@ -187,7 +187,7 @@ function addRows() {
             });
             //add newly rendered geometry if ShowAllExtents is enabled
             if ($("#show_extents_checkbox").is(":checked")) {
-                myGeoViz.addFeatureFromWKT(data["geometry"]);
+                myGeoViz.addFeatureFromWKT(data["geometry"], {"udi": data["udi"]});
             }
         }
 


### PR DESCRIPTION
To test this:
- Do a text search on data-discovery
- Turn on Show Extents
- Switch to another tab that has geometries 
- There should be no undefined geometries when hovering on the map