### PR TITLE
Feature/pelagos 3335 make remove copy selected keyword into input

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Resources/public/js/dataset-submission.js
+++ b/src/Pelagos/Bundle/AppBundle/Resources/public/js/dataset-submission.js
@@ -726,6 +726,8 @@ $(function() {
             if (option.attr("order") != undefined) {
                 source.append(option);
                 source.append(sortOptions(source.find("option").detach()));
+            } else {
+                source.val($(option).val()).focus();
             }
         }
         buildKeywordLists();

--- a/src/Pelagos/Bundle/AppBundle/Resources/public/js/datasetReview.js
+++ b/src/Pelagos/Bundle/AppBundle/Resources/public/js/datasetReview.js
@@ -296,6 +296,8 @@ $(document).ready(function(){
             if (option.attr("order") != undefined) {
                 source.append(option);
                 source.append(sortOptions(source.find("option").detach()));
+            } else {
+                source.val($(option).val()).focus();
             }
         }
         buildKeywordLists();


### PR DESCRIPTION
Double clicking a selected keyword, or clicking remove will copy the content into the input box to edit.