### PR TITLE
feature/PELAGOS-3351-add-affiliation-to-emails-sent-from-griidc-staff 

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Resources/views/Email/data-managers.dataset-submitted.email.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/Email/data-managers.dataset-submitted.email.twig
@@ -1,9 +1,10 @@
 {% block subject 'GRIIDC Dataset Submitted' %}
 
 {% block body_html %}
+    {% set submitterGroupsAndRepos = dataset.datasetSubmission.submitter.dataRepositoryNames | merge(dataset.datasetSubmission.submitter.researchGroupNames) %}
     Dear {{ recipient.firstName }} {{ recipient.lastName }},<br>
     <br>
-    A dataset has been submitted to the Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} for the dataset {{dataset.udi}}. This dataset has been assigned the doi:{{dataset.doi.doi}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ dataset.datasetSubmission.submitter.researchGroupNames | join(', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.<br>
+    A dataset has been submitted to the Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} for the dataset {{dataset.udi}}. This dataset has been assigned the doi:{{dataset.doi.doi}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ submitterGroupsAndRepos | join (', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.<br>
     <br>
     Thank you,<br>
     <br>
@@ -13,9 +14,10 @@
 {% endblock %}
 
 {% block body_text %}
+    {% set submitterGroupsAndRepos = dataset.datasetSubmission.submitter.researchGroupNames | merge(dataset.datasetSubmission.submitter.dataRepositoryNames) %}
 Dear {{ recipient.firstName }} {{ recipient.lastName }},
 
-A dataset has been submitted to the Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} for the dataset {{dataset.udi}}. This dataset has been assigned the doi:{{dataset.doi.doi}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ dataset.datasetSubmission.submitter.researchGroupNames | join(', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.
+A dataset has been submitted to the Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} for the dataset {{dataset.udi}}. This dataset has been assigned the doi:{{dataset.doi.doi}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ submitterGroupsAndRepos | join (', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.
 
 Thank you,
 

--- a/src/Pelagos/Bundle/AppBundle/Resources/views/Email/data-managers.dataset-updated.email.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/Email/data-managers.dataset-updated.email.twig
@@ -1,9 +1,10 @@
 {% block subject 'GRIIDC Dataset Submission Updated' %}
 
 {% block body_html %}
+    {% set submitterGroupsAndRepos = dataset.datasetSubmission.submitter.dataRepositoryNames | merge(dataset.datasetSubmission.submitter.researchGroupNames) %}
     Dear {{ recipient.firstName }} {{ recipient.lastName }},<br>
     <br>
-    The GRIIDC dataset {{dataset.udi}} has been updated. This update was made by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ dataset.datasetSubmission.submitter.researchGroupNames | join(', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.<br>
+    The GRIIDC dataset {{dataset.udi}} has been updated. This update was made by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ submitterGroupsAndRepos | join (', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.<br>
     <br>
     Thank you,<br>
     <br>
@@ -13,9 +14,10 @@
 {% endblock %}
 
 {% block body_text %}
+    {% set submitterGroupsAndRepos = dataset.datasetSubmission.submitter.researchGroupNames | merge(dataset.datasetSubmission.submitter.dataRepositoryNames) %}
 Dear {{ recipient.firstName }} {{ recipient.lastName }},
 
-The GRIIDC dataset {{dataset.udi}} has been updated. This update was made by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ dataset.datasetSubmission.submitter.researchGroupNames | join(', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.
+The GRIIDC dataset {{dataset.udi}} has been updated. This update was made by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ submitterGroupsAndRepos | join (', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.
 
 Thank you,
 

--- a/src/Pelagos/Entity/Person.php
+++ b/src/Pelagos/Entity/Person.php
@@ -766,6 +766,20 @@ class Person extends Entity
     }
 
     /**
+     * Get a list of the names of all Data Repositories this person is associated with.
+     *
+     * @return array
+     */
+    public function getDataRepositoryNames()
+    {
+        $dataRepositoryNames = array();
+        foreach ($this->personDataRepositories as $personDataRepository) {
+            $dataRepositoryNames[] = $personDataRepository->getDataRepository()->getName();
+        }
+        return $dataRepositoryNames;
+    }
+
+    /**
      * Setter for account.
      *
      * @param Account|null $account Account to attach to this person.


### PR DESCRIPTION
Test this in 3 cases:
- Make a submission as a GRIIDC staff only
- Make a submission as a Researcher from a research group only
- Make a submission as a member of both GRIIDC and a Researcher Group