### PR TITLE
Adding LTFS candidate tools to repo

### DIFF
--- a/share/bash/get-LTFS-candidates.sh
+++ b/share/bash/get-LTFS-candidates.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# New LTFS candidate file report generator.
+#
+# This script generates a list of new LTFS candidates, which are the set of accepted
+# datasets that are >= 25GB in size as archived on disk. The second part of this report
+# indicates any replaced datasets, which while is a very rare occurance, will require
+# updating of the files stored in LTFS/LTFS-offsite/AWS.
+
+## New Files ###################################################################
+
+# Find UDI of all .dat files > 25 GB in /san/data/store
+/bin/find /san/data/store -type f -size +25G -name "*.dat" | /bin/sed 's/\/san\/data\/store\///g' | /bin/sed 's/\/.*$//g' | /bin/sort > /var/tmp/LTFS-candidates.$$.txt;
+
+# Filter out non-accepted datasets.
+/usr/local/bin/udi-accepted-filter.pl < /var/tmp/LTFS-candidates.$$.txt > /var/tmp/LTFS-accepted-candidates.txt.$$;
+/bin/rm /var/tmp/LTFS-candidates.$$.txt;
+
+# Find files not already on list
+/usr/bin/comm -3 /var/tmp/LTFS-accepted-candidates.txt.$$ /mnt/LTFS-datasets.sorted.csv > /var/tmp/New-LTFS-accepted-candidates.txt.$$;
+/bin/rm /var/tmp/LTFS-accepted-candidates.txt.$$;
+
+# Add to report:
+/usr/bin/printf "The following list is of new, accepted datasets for consideration to copy to LTFS: \n" > /var/tmp/report.$$.txt;
+/bin/cat /var/tmp/New-LTFS-accepted-candidates.txt.$$ >> /var/tmp/report.$$.txt;
+/usr/bin/printf "\n\n" >> /var/tmp/report.$$.txt;
+
+/bin/rm /var/tmp/New-LTFS-accepted-candidates.txt.$$;
+
+## Updated Files ###############################################################
+
+# Find UDI of all recent .dat files > 25 GB in /san/data/store
+/bin/find /san/data/store -type f -size +25G -name "*.dat" -mtime -7 | /bin/sed 's/\/san\/data\/store\///g' | /bin/sed 's/\/.*$//g' | /bin/sort > /var/tmp/recent-LTFS-candidates.$$.txt;
+
+# Find possibly updated files
+/usr/bin/comm -1 -2 /var/tmp/recent-LTFS-candidates.$$.txt /mnt/LTFS-datasets.sorted.csv > /var/tmp/Updated-accepted-LTFS-datasets.txt.$$;
+
+# Add to report:
+/usr/bin/printf "LTFS datasets updated on disk within 1 week (stale LTFS copy): \n" >> /var/tmp/report.$$.txt;
+/bin/cat /var/tmp/Updated-accepted-LTFS-datasets.txt.$$ >> /var/tmp/report.$$.txt;
+/bin/rm /var/tmp/Updated-accepted-LTFS-datasets.txt.$$;
+printf "\n\n" >> /var/tmp/report.$$.txt;
+
+printf "(Any section on the reports left blank means no data fit the criteria.)\n" >> /var/tmp/report.$$.txt;
+
+## Report ######################################################################
+/bin/cat /var/tmp/report.$$.txt | /bin/mailx -s "LTFS New/Updated Report" -c "william.nichols@tamucc.edu, rosalie.rossi@tamucc.edu" michael.williamson@tamucc.edu

--- a/share/perl/udi-accepted-filter.pl
+++ b/share/perl/udi-accepted-filter.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/perl
+# Filter for Accepted datasets
+#
+# This filter only passes UDIs that correspond to datasets that are
+# in the accepted state. Typical usage is to pipe a textfile of UDIs
+# to it that represent datasets in various states, and the resulting
+# output is just those UDIs of accepted datasets. This script is used
+# by the Pelagos LTFS tools.
+
+use JSON::Parse 'parse_json';
+use Data::Dumper;
+
+while(<>) {
+    chomp($_);
+    my $udi = $_;
+    my $statusJSON = `curl -s "https://data.gulfresearchinitiative.org/pelagos-symfony/api/datasets?udi=$udi&_properties=datasetStatus"`;
+    my $status= parse_json($statusJSON);
+    my $hashref = @$status[0];
+    my %hash = %$hashref;
+    my $accepted = $hash{'datasetStatus'};
+    if ($accepted eq 'Accepted' ) {
+        print "$udi\n";
+    }
+}


### PR DESCRIPTION
I feel this LTFS stuff is now a part of Pelagos and really should be in a repository.  If y'all think this is better placed in a different repo, let me know. Typical usage of these scripts is to launch from cron and symlink to /usr/local/bin, but I'm flexible if we should rather run them from /opt/pelagos and have a parameter for pelagos_home in the scripts to reference things with relative paths.