### PR TITLE
 feature/PELAGOS-3397-add-geofilter-to-search-terms-report

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Controller/UI/SearchTermsReportController.php
+++ b/src/Pelagos/Bundle/AppBundle/Controller/UI/SearchTermsReportController.php
@@ -54,10 +54,11 @@ class SearchTermsReportController extends ReportController
     {
         //prepare labels
         $labels = array('labels' => array(
-            'SESSION ID', 'TIMESTAMP', 'SEARCH TERMS', 'NUMBER OF RESULTS',
+            'SESSION ID', 'TIMESTAMP', 'SEARCH TERMS', 'GEOFILTER USED', 'NUMBER OF RESULTS',
             '1ST SCORE', '2ND SCORE',
             '1ST UDI', '1ST TITLE', '1ST LINK',
-            '2ND UDI', '2ND TITLE', '2ND LINK'
+            '2ND UDI', '2ND TITLE', '2ND LINK',
+            'GEOFILTER WKT'
             )
         );
 
@@ -131,9 +132,14 @@ class SearchTermsReportController extends ReportController
                     'sessionID' => $result['payLoad']['clientInfo']['sessionId'],
                     'timeStamp' => $result['creationTimeStamp']->format(parent::INREPORT_TIMESTAMPFORMAT),
                     'searchTerms' => $result['payLoad']['filters']['textFilter'],
+                    'geofilterUsed' => $result['payLoad']['filters']['geoFilter'] !== null ? 1 : 0,
                     'numResults' => $numResults
                 ),
-                $searchResults
+                $searchResults,
+                array
+                (
+                    'geofilterWkt' => $result['payLoad']['filters']['geoFilter'] !== null ? $result['payLoad']['filters']['geoFilter'] : ''
+                )
             );
         }
         return array_merge($labels, $dataArray);


### PR DESCRIPTION
We don't need to worry about the legacy search log since the action item log table has been recording geofilter information