### PR TITLE
Feature/pelagos 3396 dload add datause policy

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Resources/views/Download/download-external-resource-splash-screen.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/Download/download-external-resource-splash-screen.html.twig
@@ -43,12 +43,16 @@
 
         <div style="border: 1px solid #aaa; padding: 10px; margin-top: 20px; border-radius: 4px;">
             <p style="margin-top:0">
-                <strong>DISCLAIMER:</strong> The Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) aggregates data from researchers funded by the Gulf of Mexico Research Initiative and other scientists working in the region. These data are furnished "as is" for the convenience of all data users. GRIIDC makes no warranties (including no warranties as to merchantability, timeliness or fitness) either expressed or implied with respect to the data or their fitness for any specific application.  This particular dataset is not hosted directly by GRIIDC, so additional terms and conditions may be imposed by the hosting entity.
+                All materials on this website are made available to GRIIDC and in turn to you "as-is." There is no
+                warranty (expressed or implied) to these materials, their title, accuracy, non-infringement of third
+                party rights, or fitness for any particular purpose, including the performance or results you may
+                obtain from their use. Use these materials at your own risk. Under no circumstances shall GRIIDC be
+                liable for any direct, incidental, special, consequential, indirect, or punitive damages that result
+                from the use or the inability to use either this website or the materials available via this website.
+                If you are dissatisfied with any website feature, content, or terms of use, your sole and exclusive
+                remedy is to discontinue use.
             </p>
             <div style="text-align:center;">
-                <p>
-                    By using the link above, you agree to the GRIIDC terms in the above disclaimer.
-                </p>
                 <p style="margin-bottom:0">
                     <button class="close_button" style="font-weight:bold;margin:10px 10px 10px 0px;">Cancel</button>
                 </p>

--- a/src/Pelagos/Bundle/AppBundle/Resources/views/Download/download-external-resource-splash-screen.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/Download/download-external-resource-splash-screen.html.twig
@@ -12,35 +12,6 @@
         <h3 style="text-align:center;">The dataset you selected is hosted by an external repository.</h3>
         {% endif %}
 
-        <div style="border: 1px solid #aaa; padding: 10px; border-radius: 4px;">
-            <p style="margin-top:0"><strong>UDI:</strong> {{dataset.udi}}</p>
-
-            <p><strong>Title:</strong> {{dataset.title}}</p>
-
-            <p><strong>Author(s):</strong> {{dataset.datasetSubmission.authors}}</p>
-
-            {% if dataset.datasetStatus == constant('Pelagos\\Entity\\Dataset::DATASET_STATUS_ACCEPTED') %}
-                <p>
-                    <strong>Metadata:</strong>
-                    <a href="{{ path('pelagos_app_ui_dataland_metadata', {'udi': dataset.udi}) }}">{{ dataset.udi|replace({':': '-'}) }}-metadata.xml</a>
-                </p>
-            {% endif %}
-
-            <p>
-                <strong>Location:</strong>
-                <a href="{{dataset.datasetSubmission.datasetFileUri}}" target=_BLANK>
-                    {{dataset.datasetSubmission.datasetFileUri}}
-                </a>
-            </p>
-
-            {% if dataset.availabilityStatus == constant('Pelagos\\Entity\\DatasetSubmission::AVAILABILITY_STATUS_RESTRICTED_REMOTELY_HOSTED') %}
-                <p style="color:#A00">This dataset is restricted for download but is hosted by another website so availability status is not guaranteed to be accurate.<br>To obtain access to this dataset, please click the location link above and follow any instructions provided.</p>
-            {% else %}
-                <p>To download this dataset, please use the location link above. Note, this dataset is not hosted at GRIIDC; the site is not under GRIIDC control and GRIIDC is not responsible for the information or links you may find there.</p>
-            {% endif %}
-
-        </div>
-
         <div style="border: 1px solid #aaa; padding: 10px; margin-top: 20px; border-radius: 4px;">
             <p style="margin-top:0">
                 All materials on this website are made available to GRIIDC and in turn to you "as-is." There is no
@@ -52,12 +23,38 @@
                 If you are dissatisfied with any website feature, content, or terms of use, your sole and exclusive
                 remedy is to discontinue use.
             </p>
+            <p style="margin-top:0">
+                This particular dataset is not hosted directly by GRIIDC, so additional terms and conditions may be
+                imposed by the hosting entity.
+            </p>
             <div style="text-align:center;">
                 <p style="margin-bottom:0">
                     <button class="close_button" style="font-weight:bold;margin:10px 10px 10px 0px;">Cancel</button>
                 </p>
             </div>
         </div>
+        &nbsp;
+        <div style="border: 1px solid #aaa; padding: 10px; border-radius: 4px;">
+            <p style="margin-top:0">
+            <strong>UDI:</strong> {{dataset.udi}}<br />
+            <strong>Title:</strong> {{dataset.title}}<br />
+            <strong>Author(s):</strong> {{dataset.datasetSubmission.authors}}<br />
+            {% if dataset.datasetStatus == constant('Pelagos\\Entity\\Dataset::DATASET_STATUS_ACCEPTED') %}
+                    <strong>Metadata:</strong>
+                    <a href="{{ path('pelagos_app_ui_dataland_metadata', {'udi': dataset.udi}) }}">{{ dataset.udi|replace({':': '-'}) }}-metadata.xml</a><br />
+            {% endif %}
+            <strong>Location:</strong>
+            <a href="{{dataset.datasetSubmission.datasetFileUri}}" target=_BLANK>
+                {{dataset.datasetSubmission.datasetFileUri}}
+            </a><br />
+
+            {% if dataset.availabilityStatus == constant('Pelagos\\Entity\\DatasetSubmission::AVAILABILITY_STATUS_RESTRICTED_REMOTELY_HOSTED') %}
+                <p style="color:#A00">This dataset is restricted for download but is hosted by another website so availability status is not guaranteed to be accurate.<br>To obtain access to this dataset, please click the location link above and follow any instructions provided.</p>
+            {% else %}
+                <p>To download this dataset, please use the location link above. Note, this dataset is not hosted at GRIIDC; the site is not under GRIIDC control and GRIIDC is not responsible for the information or links you may find there.</p>
+            {% endif %}
+        </div>
+
 
     </div>
 

--- a/src/Pelagos/Bundle/AppBundle/Resources/views/Download/download-splash-screen.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/Download/download-splash-screen.html.twig
@@ -55,12 +55,16 @@
 
         <div style="border: 1px solid #aaa; padding: 10px; margin-top: 15px; border-radius: 4px;">
             <p style="margin-top:0">
-                <strong>DISCLAIMER:</strong> The Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) aggregates data from researchers funded by the Gulf of Mexico Research Initiative and other scientists working in the region. These data are furnished "as is" for the convenience of all data users. GRIIDC makes no warranties (including no warranties as to merchantability, timeliness or fitness) either expressed or implied with respect to the data or their fitness for any specific application.
+                All materials on this website are made available to GRIIDC and in turn to you "as-is." There is no
+                warranty (expressed or implied) to these materials, their title, accuracy, non-infringement of third
+                party rights, or fitness for any particular purpose, including the performance or results you may
+                obtain from their use. Use these materials at your own risk. Under no circumstances shall GRIIDC be
+                liable for any direct, incidental, special, consequential, indirect, or punitive damages that result
+                from the use or the inability to use either this website or the materials available via this website.
+                If you are dissatisfied with any website feature, content, or terms of use, your sole and exclusive
+                remedy is to discontinue use.
             </p>
             <div style="text-align:left;">
-                <p>
-                    By downloading data you are expressing agreement with the disclaimer.
-                </p>
                 <div style="width: 100%; display: table; border: 1px solid #aaa; border-radius: 4px;">
                     <div style="display: table-row; margin: 0 auto;">
                         <div style="display: table-cell;">


### PR DESCRIPTION
I also used this data use policy on the external splash screen, but kept the line in place "This particular dataset is not hosted directly by GRIIDC, so additional terms and conditions may be imposed by the hosting entity." This likely needs to be approved upstream, but the external splash screen was a mess.
