### PR TITLE
Added file info to dataland template.

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Resources/views/Dataland/details.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/Dataland/details.html.twig
@@ -30,6 +30,14 @@
         </div>
     {% endif %}
 
+    {% if dataset.datasetSubmission.datasetFilename|default %}
+        <h2>Filename:</h2>
+        <div>
+            {{ dataset.datasetSubmission.datasetFilename|default }} ({{ dataset.datasetSubmission.datasetFileSize|formatBytes }})
+        </div>
+    {% endif %}
+
+
     {% if downloads is not null %}
         <h2>Dataset Downloads:</h2>
         <div>


### PR DESCRIPTION
I confirmed the custom twig extension that we use to format bytes into human-readable form is indeed based on powers of 10, so that simplified things.