### PR TITLE
Feature/pelagos 3454 have drupal not overwrite our error codes

### DIFF
--- a/app/drupal_send_and_terminate.php
+++ b/app/drupal_send_and_terminate.php
@@ -34,7 +34,11 @@ if (get_class($response) == 'Pelagos\Response\TerminateResponse') {
     exit();
 }
 
-if (preg_match('/^Pelagos\\\\Bundle\\\\AppBundle\\\\Controller\\\\Api\\\\/', $request->attributes->get('_controller'))) {
+if (preg_match(
+    '/^Pelagos\\\\Bundle\\\\AppBundle\\\\Controller\\\\Api\\\\/',
+    $request->attributes->get('_controller')
+)
+    ) {
     $response->send();
     $kernel->terminate($request, $response);
     exit();

--- a/app/drupal_send_and_terminate.php
+++ b/app/drupal_send_and_terminate.php
@@ -71,6 +71,9 @@ if (in_array(
     exit();
 }
 
+// Make drupal return the response code we specify.
+drupal_add_http_header('status', $response->getStatusCode());
+
 if (preg_match('/^Pelagos\\\\/', $request->attributes->get('_controller'))
     or $request->attributes->get('_route') === null
     or $request->attributes->get('_route') === '_twig_error_test'


### PR DESCRIPTION
To test, open the browser developer console and take note of the response code shown as you load a dataset and a non-existant dataset, or tombstone, or any other resource. This fix propagates the symfony-generated status code through Drupal wherever Drupal is wraping Pelagos. 