### PR TITLE
Feature/pelagos 3475 make controller cs aware

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Controller/UI/StatsController.php
+++ b/src/Pelagos/Bundle/AppBundle/Controller/UI/StatsController.php
@@ -217,11 +217,11 @@ class StatsController extends UIController
             $qb->join('d.datasetSubmission', 'ds');
 
             if (array_key_exists('range0', $range)) {
-                $qb->andWhere('ds.datasetFileSize > :range0');
+                $qb->andWhere('COALESCE(ds.datasetFileColdStorageArchiveSize, ds.datasetFileSize) > :range0');
                 $qb->setParameter('range0', $range['range0']);
             }
             if (array_key_exists('range1', $range)) {
-                $qb->andWhere('ds.datasetFileSize <= :range1');
+                $qb->andWhere('COALESCE(ds.datasetFileColdStorageArchiveSize, ds.datasetFileSize) <= :range1');
                 $qb->setParameter('range1', $range['range1']);
             }
 

--- a/src/Pelagos/Bundle/AppBundle/Resources/public/js/stats.js
+++ b/src/Pelagos/Bundle/AppBundle/Resources/public/js/stats.js
@@ -32,10 +32,10 @@ $(document).ready(function() {
                 numbers: {
                     show: true,
                     yAlign: function(plot,y) {
-                        if (y < 25) {
+                        if (y <= 100) {
                             return plot.getAxes().yaxis.c2p(plot.getAxes().yaxis.p2c(y)-1);
                         } else {
-                            return plot.getAxes().yaxis.c2p(plot.getAxes().yaxis.p2c(y)+14)
+                            return plot.getAxes().yaxis.c2p(plot.getAxes().yaxis.p2c(y)+15)
                         }
                     },
                     xAlign: function(plot,x) { return x + 0.4; }


### PR DESCRIPTION
To test this, first merge in feature/PELAGOS-3470 (if it isn't already merged into develop).
Bring up Stats page and take note of bargraph/counts.

Fake some cold storage entries:
ex:  UPDATE dataset_submission SET dataset_file_cold_storage_archive_size = 20000000000000 WHERE id = (SELECT dataset_submission_id FROM dataset WHERE udi = 'Y1.x136.017:0001');

View bargraph again and compare. You should see the size of the original column go down by one and the >1TB column increase by one.