### PR TITLE
Refactor/sorted manifest generator

### DIFF
--- a/share/bash/create-manifest.sh
+++ b/share/bash/create-manifest.sh
@@ -42,3 +42,5 @@ unix2dos $hashfile
 mv $hashfile $udi
 zip -r $zipfile $udi/
 unzip -l $zipfile
+
+rm -rf $udi

--- a/share/bash/create-manifest.sh
+++ b/share/bash/create-manifest.sh
@@ -25,14 +25,20 @@ readmefile="$udi-ReadMe.txt"
 manifestfile="$udi-file-manifest.txt"
 zipfile="$udi-manifest.zip"
 
+echo "Generating temporary directory $udi"
+mkdir "$udi"
+
 echo "Generating file: $path/$udi-ReadMe.txt"
-python share/python/create-tree.py -d $1 > $readmefile
-unix2dos $readmefile
+python share/python/create-tree.py -d $1 > $udi/$readmefile
+unix2dos $udi/$readmefile
 
-echo "Generating file: $path/$udi-file-manifest.txt"
-python share/python/create-tree.py $1 > $manifestfile
-unix2dos $manifestfile
+echo "Generating file: $path/$udi/$udi-file-manifest.txt"
+python share/python/create-tree.py $1 > $udi/$manifestfile
+unix2dos $udi/$manifestfile
 
-zip $zipfile $1
-zip $zipfile -m $manifestfile $readmefile
+cp $1 .
+hashfile=$(basename $1)
+unix2dos $hashfile
+mv $hashfile $udi
+zip -r $zipfile $udi/
 unzip -l $zipfile

--- a/share/python/directory_tree_node.py
+++ b/share/python/directory_tree_node.py
@@ -1,7 +1,7 @@
 '''
 This class models a node in a tree of nodes
 representing a node in a file system directory tree.
-Each node has a name and a size in bytes. The name 
+Each node has a name and a size in bytes. The name
 represents the name of the node in the directory/filename
 path.
 
@@ -90,8 +90,12 @@ class DirectoryTreeNode(object):
         s = s + self.getName()
 
         print (formatString.format(s,DirectoryTreeNode.intToSize(self.getSize())))
+        # Custom sorter for use in sorting childrenList below.
+        def mysorter(elem):
+            return elem.getName()
+
         childrenList = self.getChildren()
-        for child in childrenList:
+        for child in sorted(childrenList, key=mysorter):
             child.printTree(indentations + 1)
         return
 


### PR DESCRIPTION
I've made a few modifications to the manifest generator:
1) sorted output (note uppercase sorts first)
2) modified wrapper to run from pelagos basedir
3) modified zip to include a top-level directory