### PR TITLE
Parse distributionUrl protocol instead of hardcode.

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Resources/views/MetadataGenerator/MD_Distribution.xml.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/MetadataGenerator/MD_Distribution.xml.twig
@@ -106,7 +106,7 @@
                                 <gmd:URL>{{ distPoint.distributionUrl }}</gmd:URL>
                             </gmd:linkage>
                             <gmd:protocol>
-                                <gco:CharacterString>https</gco:CharacterString>
+                                <gco:CharacterString>{{ distPoint.distributionUrlProtocol }}</gco:CharacterString>
                             </gmd:protocol>
                             <gmd:name>
                                 <gco:CharacterString>Data Landing Page</gco:CharacterString>

--- a/src/Pelagos/Entity/DistributionPoint.php
+++ b/src/Pelagos/Entity/DistributionPoint.php
@@ -34,12 +34,12 @@ class DistributionPoint extends Entity
         ],
         'custodian' => [
             'name' => 'Custodian',
-            'description' => 'The individual/organization that has 
+            'description' => 'The individual/organization that has
                 accountability and responsibility for the data.',
         ],
         'originator' => [
             'name' => 'Originator',
-            'description' => 'the name of the individual or organization who is responsible 
+            'description' => 'the name of the individual or organization who is responsible
                   for the data at the point when the data was first created.',
         ],
         'owner' => [
@@ -57,7 +57,7 @@ class DistributionPoint extends Entity
         ],
         'processor' => [
             'name' => 'Processor',
-            'description' => 'The name of the individual or organization who 
+            'description' => 'The name of the individual or organization who
                 has processed the data in a manner such that the resource has been modified.',
         ],
         'publisher' => [
@@ -66,7 +66,7 @@ class DistributionPoint extends Entity
         ],
         'resourceProvider' => [
             'name' => 'Resource Provider',
-            'description' => 'The individual or organization that supplies 
+            'description' => 'The individual or organization that supplies
                 or allocates the resource for another entity.',
         ],
         'user' => [
@@ -191,7 +191,7 @@ class DistributionPoint extends Entity
     public function getDistributionUrlProtocol()
     {
         if ($this->distributionUrl !== null) {
-            preg_match('/^((.*?):).*$/', $this->distributionUrl, $matches);
+            preg_match('/^(.*?):.*$/', $this->distributionUrl, $matches);
             return $matches[2];
         } else {
             return null;

--- a/src/Pelagos/Entity/DistributionPoint.php
+++ b/src/Pelagos/Entity/DistributionPoint.php
@@ -192,7 +192,7 @@ class DistributionPoint extends Entity
     {
         if ($this->distributionUrl !== null) {
             preg_match('/^(.*?):.*$/', $this->distributionUrl, $matches);
-            return $matches[2];
+            return $matches[1];
         } else {
             return null;
         }

--- a/src/Pelagos/Entity/DistributionPoint.php
+++ b/src/Pelagos/Entity/DistributionPoint.php
@@ -184,6 +184,21 @@ class DistributionPoint extends Entity
     }
 
     /**
+     * Getter for distribution url protocol.
+     *
+     * @return string
+     */
+    public function getDistributionUrlProtocol()
+    {
+        if ($this->distributionUrl !== null) {
+            preg_match('/^((.*?):).*$/', $this->distributionUrl, $matches);
+            return $matches[2];
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Setter for role code.
      *
      * @param string $roleCode The CI_ROLECODE for this association.

--- a/tests/unit/Pelagos/Entity/DistributionPointTest.php
+++ b/tests/unit/Pelagos/Entity/DistributionPointTest.php
@@ -32,7 +32,6 @@ class DistributionPointTest extends TestCase
         $this->mockDatasetSubmission = \Mockery::mock('\Pelagos\Entity\DatasetSubmission');
         $this->mockDataCenter = \Mockery::mock('\Pelagos\Entity\DataCenter');
         $this->distributionPoint = new DistributionPoint;
-
     }
 
     /**
@@ -82,6 +81,27 @@ class DistributionPointTest extends TestCase
             $mockDistributionUrl,
             $this->distributionPoint->getDistributionUrl()
         );
+    }
+
+    /**
+     * Test the Distribution Url Protocol getter method.
+     *
+     * This method should test the Distribution Url's protocol string.
+     *
+     * @return void
+     */
+    public function testCanGetDistributionUrlProtocol()
+    {
+        $mockDistributionUrlProtocol = 'ftps';
+        $mockDistributionUrl = "$mockDistributionUrlProtocol://hostname.site.tld";
+        $this->distributionPoint->setDistributionUrl($mockDistributionUrl);
+        $this->assertEquals(
+            $mockDistributionUrlProtocol,
+            $this->distributionPoint->getDistributionUrlProtocol()
+        );
+        // Also try it if URL is null.
+        $this->distributionPoint->setDistributionUrl(null);
+        $this->assertNull($this->distributionPoint->getDistributionUrlProtocol());
     }
 
     /**


### PR DESCRIPTION
In another ticket it was discovered we were hardcoding 'https' instead of parsing from the distributionUrl. PO suggested it would be better to parse instead of hardcode.