### PR TITLE
Feature/pelagos 3548 allow version and production builds for web pack

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -40,7 +40,8 @@ framework:
         storage_id: session.storage.native
     fragments:       ~
     http_method_override: true
-    assets: ~
+    assets:
+        json_manifest_path: '%kernel.project_dir%/web/build/manifest.json'
 
 # Twig Configuration
 twig:

--- a/src/Pelagos/Bundle/AppBundle/Resources/views/layout.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/layout.html.twig
@@ -7,12 +7,12 @@
     <link rel="icon" type="image/x-icon" href="{{ asset('/build/images/griidc_fav.png') }}" />
 
     {%block stylesheets %}
-        <link href="{{ asset('/build/common.css') }}" rel="stylesheet" />
+        <link href="{{ asset('build/common.css') }}" rel="stylesheet" />
         <link href="//cdnjs.cloudflare.com/ajax/libs/qtip2/2.2.0/jquery.qtip.min.css" rel="stylesheet" />
     {%endblock stylesheets  %}
 
     {% block javascripts %}
-        <script src="{{ asset('/build/common.js') }}"></script>
+        <script src="{{ asset('build/common.js') }}"></script>
         
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.hoverintent/1.9.0/jquery.hoverIntent.min.js"></script>
 

--- a/src/Pelagos/Bundle/AppBundle/Resources/views/layout.ui.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/layout.ui.html.twig
@@ -1,0 +1,24 @@
+{% extends "PelagosAppBundle::layout.html.twig" %}
+
+{%block stylesheets %}
+    {{ parent() }}
+    
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    
+    <link rel="stylesheet" href="{{ asset('build/layout.css') }}">
+{%endblock stylesheets  %}
+
+{% block javascripts %}
+    {{ parent() }}
+    
+    <script src="{{ asset('build/layout.js') }}"></script>
+
+    {{
+        add_js(
+            [
+                '//cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.11.1/jquery.validate.min.js',
+                '//cdnjs.cloudflare.com/ajax/libs/jquery-noty/2.3.5/packaged/jquery.noty.packaged.min.js',
+            ]
+        )
+    }}
+{% endblock %}

--- a/src/Pelagos/Bundle/AppBundle/Resources/views/template/UI.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/template/UI.html.twig
@@ -3,7 +3,7 @@
 {%block stylesheets %}
     {{ parent() }}
 
-    <link rel="stylesheet" href="{{ asset('/build/layout.css') }}">
+    <link rel="stylesheet" href="{{ asset('build/layout.css') }}">
 
     {{
         add_css (
@@ -23,7 +23,7 @@
 {% block javascripts %}
     {{ parent() }}
 
-    <script src="{{ asset('/build/layout.js') }}"></script>
+    <script src="{{ asset('build/layout.js') }}"></script>
 
     {{
         add_js(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,6 @@ Encore
     // will create web/build/app.js and web/build/app.css
     .createSharedEntry('common', './assets/js/common.js')
     .addEntry('layout', './assets/js/layout.js')
-    
 
     // allow sass/scss files to be processed
     //.enableSassLoader()
@@ -30,9 +29,12 @@ Encore
     // show OS notifications when builds finish/fail
     //.enableBuildNotifications()
 
+    // Add or change path of build asset location
+    //.setManifestKeyPrefix('../build')
+
     // create hashed filenames (e.g. app.abc123.css)
-    //.enableVersioning()
-    
+    .enableVersioning(Encore.isProduction())
+
     // No runtime.js needed.
     .disableSingleRuntimeChunk()
 


### PR DESCRIPTION
To test: `yarn encore dev` will produce regular file names (common.css.js layout.css.js)
'yarn encore prod' will add a hash, and due to manifest.json will load correctly.