### PR TITLE
Feature/pelagos 3562 add abstract and theme to index and search query

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -313,8 +313,10 @@ fos_elastica:
                     types:
                         dataset:
                             properties:
-                                title: ~
-                                abstract: ~
+                                title:
+                                    type: 'text'
+                                abstract:
+                                    type: 'text'
                                 researchGroup:
                                     type: 'nested'
                                     properties:
@@ -324,7 +326,10 @@ fos_elastica:
                                 datasetSubmission:
                                     type: 'nested'
                                     properties:
-                                        authors: ~
+                                        authors:
+                                            type: 'text'
+                                        themeKeywords:
+                                            type: 'text'
                             persistence:
                                 driver: orm
                                 model: Pelagos\Entity\Dataset

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -314,6 +314,7 @@ fos_elastica:
                         dataset:
                             properties:
                                 title: ~
+                                abstract: ~
                                 researchGroup:
                                     type: 'nested'
                                     properties:

--- a/src/Pelagos/Util/Search.php
+++ b/src/Pelagos/Util/Search.php
@@ -33,33 +33,13 @@ class Search
     protected $entityManager;
 
     /**
-     * Elastic index title field.
-     */
-    const TITLE = 'title';
-
-    /**
-     * Elastic index abstract field.
-     */
-    const ABSTRACT = 'abstract';
-
-    /**
-     * Elastic index dataset submission authors field.
-     */
-    const DS_AUTHORS = 'datasetSubmission.authors';
-
-    /**
-     * Elastic index dataset submission theme keywords field.
-     */
-    const DS_THEME_KEYWORDS = 'datasetSubmission.themeKeywords';
-
-    /**
      * Elastic index mapping.
      */
     const ELASTIC_INDEX_MAPPING = array(
-        'title' => self::TITLE,
-        'abstract' => self::ABSTRACT,
-        'dsubAuthors' => self::DS_AUTHORS,
-        'dsubThemeKeywords' => self::DS_THEME_KEYWORDS
+        'title' => 'title',
+        'abstract' => 'abstract',
+        'dsubAuthors' => 'datasetSubmission.authors',
+        'dsubThemeKeywords' => 'datasetSubmission.themeKeywords'
     );
 
     /**

--- a/src/Pelagos/Util/Search.php
+++ b/src/Pelagos/Util/Search.php
@@ -35,22 +35,32 @@ class Search
     /**
      * Elastic index title field.
      */
-    const INDEX_FIELD_TITLE = 'title';
+    const TITLE = 'title';
 
     /**
      * Elastic index abstract field.
      */
-    const INDEX_FIELD_ABSTRACT = 'abstract';
+    const ABSTRACT = 'abstract';
 
     /**
      * Elastic index dataset submission authors field.
      */
-    const INDEX_FIELD_DS_AUTHOR = 'datasetSubmission.authors';
+    const DS_AUTHORS = 'datasetSubmission.authors';
 
     /**
      * Elastic index dataset submission theme keywords field.
      */
-    const INDEX_FIELD_DS_THEME_KEYWORDS = 'datasetSubmission.themeKeywords';
+    const DS_THEME_KEYWORDS = 'datasetSubmission.themeKeywords';
+
+    /**
+     * Elastic index mapping.
+     */
+    const ELASTIC_INDEX_MAPPING = array(
+        'title' => self::TITLE,
+        'abstract' => self::ABSTRACT,
+        'dsubAuthors' => self::DS_AUTHORS,
+        'dsubThemeKeywords' => self::DS_THEME_KEYWORDS
+    );
 
     /**
      * Constructor.
@@ -113,15 +123,15 @@ class Search
 
         // Add title field to the query
         $titleQuery = new Query\Match();
-        $titleQuery->setFieldQuery(self::INDEX_FIELD_TITLE, $queryTerm);
-        $titleQuery->setFieldOperator(self::INDEX_FIELD_TITLE, 'and');
-        $titleQuery->setFieldBoost(self::INDEX_FIELD_TITLE, 2);
+        $titleQuery->setFieldQuery(self::ELASTIC_INDEX_MAPPING['title'], $queryTerm);
+        $titleQuery->setFieldOperator(self::ELASTIC_INDEX_MAPPING['title'], 'and');
+        $titleQuery->setFieldBoost(self::ELASTIC_INDEX_MAPPING['title'], 2);
         $fieldsBoolQuery->addShould($titleQuery);
 
         // Add title field to the query
         $abstractQuery = new Query\Match();
-        $abstractQuery->setFieldQuery(self::INDEX_FIELD_ABSTRACT, $queryTerm);
-        $abstractQuery->setFieldOperator(self::INDEX_FIELD_ABSTRACT, 'and');
+        $abstractQuery->setFieldQuery(self::ELASTIC_INDEX_MAPPING['abstract'], $queryTerm);
+        $abstractQuery->setFieldOperator(self::ELASTIC_INDEX_MAPPING['abstract'], 'and');
         $fieldsBoolQuery->addShould($abstractQuery);
 
         // Create nested for datasetSubmission fields
@@ -132,16 +142,16 @@ class Search
         $datasetSubmissionBoolQuery = new Query\BoolQuery();
 
         $themeKeywordsQuery = new Query\Match();
-        $themeKeywordsQuery->setFieldQuery(self::INDEX_FIELD_DS_THEME_KEYWORDS, $queryTerm);
-        $themeKeywordsQuery->setFieldOperator(self::INDEX_FIELD_DS_THEME_KEYWORDS, 'and');
-        $themeKeywordsQuery->setFieldBoost(self::INDEX_FIELD_DS_THEME_KEYWORDS, 2);
+        $themeKeywordsQuery->setFieldQuery(self::ELASTIC_INDEX_MAPPING['dsubThemeKeywords'], $queryTerm);
+        $themeKeywordsQuery->setFieldOperator(self::ELASTIC_INDEX_MAPPING['dsubThemeKeywords'], 'and');
+        $themeKeywordsQuery->setFieldBoost(self::ELASTIC_INDEX_MAPPING['dsubThemeKeywords'], 2);
         $datasetSubmissionBoolQuery->addShould($themeKeywordsQuery);
 
         // Add datasetSubmission author field to the query
         $authorQuery = new Query\Match();
-        $authorQuery->setFieldQuery(self::INDEX_FIELD_DS_AUTHOR, $queryTerm);
-        $authorQuery->setFieldOperator(self::INDEX_FIELD_DS_AUTHOR, 'and');
-        $authorQuery->setFieldBoost(self::INDEX_FIELD_DS_AUTHOR, 2);
+        $authorQuery->setFieldQuery(self::ELASTIC_INDEX_MAPPING['dsubAuthors'], $queryTerm);
+        $authorQuery->setFieldOperator(self::ELASTIC_INDEX_MAPPING['dsubAuthors'], 'and');
+        $authorQuery->setFieldBoost(self::ELASTIC_INDEX_MAPPING['dsubAuthors'], 2);
         $datasetSubmissionBoolQuery->addShould($authorQuery);
 
         $datasetSubmissionQuery->setQuery($datasetSubmissionBoolQuery);


### PR DESCRIPTION
To test:
Search with theme keywords Ex: BTEX PIANO benzene toluene
Should return BP.x750.000:0005, BP.x750.000:0027 and few other BP datasets

Search with abstract Ex: Hydrographic and water column data were collected during cruises EN509 and EN510 (sequential legs) using a CTD-rosette system aboard the R/V Endeavor. We characterized the physical and chemical properties in the water column at the ECOGIG seep and other study sites. The ship departed Gulfport MS on for cruise EN509 on 05/25/2012 and collected samples at ECOGIG and other sites before returning to Gulfport on 06/20/2012. Cruise EN510 departed Pascagoula MS (relocated to avoid a hurricane) on 06/25/2012 and collected samples at ECOGIG seep and control sites before returning to Gulfport MS on 07/05/2012. Binned profiles and bottle files are available.

Should return udi: R1.x132.134:0003, Try putting in different parts of the abstract. 