### PR TITLE
Change from db to host restriction.

### DIFF
--- a/bin/loaddump
+++ b/bin/loaddump
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Don't run from normal production. This is for loading dev/test/demo/offsite environments only.
+hostname=$(hostname)
+if [ $hostname == 'griidc-prod.tamucc.edu' ]; then
+    echo "This script is not to be run for production."
+    exit
+fi
+
 parse_yaml() {
    local prefix=$2
    local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
@@ -71,14 +78,6 @@ if [ "$#" -eq 2 ]; then
 fi
 
 bin/console rabbitmq-supervisor:control stop
-
-# Safety Dance
-for db in postgres pelagos template0 template1 gomri drupal drupal_db bamboo_db jira confluence stash; do
-    if [ "$parameters__database_name" == "$db" ]; then
-        echo "Refusing to alter database $parameters__database_name!"
-        exit
-    fi
-done
 
 # Drop existing database
 echo "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$parameters__database_name' AND pid <> pg_backend_pid();" | psql -h $parameters__database_host -U postgres || exit


### PR DESCRIPTION
just making bin/loaddump a little more sane - it now will run without commenting out the db check, but will not for the production host. I think this is a more effective safety measure than the way I had it before.