### PR TITLE
Feature/pelagos 3739 add locked to research group form

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Form/ResearchGroupType.php
+++ b/src/Pelagos/Bundle/AppBundle/Form/ResearchGroupType.php
@@ -4,6 +4,9 @@ namespace Pelagos\Bundle\AppBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
@@ -83,6 +86,15 @@ class ResearchGroupType extends AbstractType
             ->add('emailAddress', TextType::class, array(
                 'label' => 'E-Mail Address:',
                 'required' => false,
+            ))
+            ->add('locked', ChoiceType::class, array(
+                'choices' => [
+                    'Yes' => true,
+                    'No' => false,
+                ],
+                'placeholder' => '[PLEASE SELECT A STATE]',
+                'label' => 'Closed Out:',
+                'required' => true,
             ));
     }
 

--- a/src/Pelagos/Bundle/AppBundle/Form/ResearchGroupType.php
+++ b/src/Pelagos/Bundle/AppBundle/Form/ResearchGroupType.php
@@ -4,8 +4,6 @@ namespace Pelagos\Bundle\AppBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;

--- a/src/Pelagos/Bundle/AppBundle/Resources/views/template/forms/ResearchGroup.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/template/forms/ResearchGroup.html.twig
@@ -50,5 +50,7 @@ _action="{{path('pelagos_api_research_groups_post')}}">
 
     {{ form_row(form.emailAddress) }}
 
+    {{ form_row(form.locked) }}
+
     {% include '@templates/forms/innerForm.html.twig' with {'Entity': ResearchGroup} %}
 </form>

--- a/src/Pelagos/Entity/ResearchGroup.php
+++ b/src/Pelagos/Entity/ResearchGroup.php
@@ -298,6 +298,12 @@ class ResearchGroup extends Entity
      *
      * @var boolean $locked
      *
+     * @access public
+     *
+     * @Assert\NotNull(
+     *     message="Please select Yes or No"
+     * )
+     *
      * @ORM\Column(type="boolean", nullable=false)
      */
     protected $locked = false;
@@ -702,6 +708,20 @@ class ResearchGroup extends Entity
     public function isLocked()
     {
         return $this->locked;
+    }
+
+    /**
+     * Setter for locked.
+     *
+     * @param boolean $locked Containing desired state of lock
+     *
+     * @access public
+     *
+     * @return void
+     */
+    public function setLocked($locked)
+    {
+        $this->locked = $locked;
     }
 
     /**

--- a/src/Pelagos/Entity/ResearchGroup.php
+++ b/src/Pelagos/Entity/ResearchGroup.php
@@ -675,30 +675,6 @@ class ResearchGroup extends Entity
     }
 
     /**
-     * Method to lock Research Group.
-     *
-     * @access public
-     *
-     * @return void
-     */
-    public function lock()
-    {
-        $this->locked = true;
-    }
-
-    /**
-     * Method to unlock Research Group.
-     *
-     * @access public
-     *
-     * @return void
-     */
-    public function unlock()
-    {
-        $this->locked = false;
-    }
-
-    /**
      * Method to check if Research Group is locked.
      *
      * @access public
@@ -713,7 +689,7 @@ class ResearchGroup extends Entity
     /**
      * Setter for locked.
      *
-     * @param boolean $locked Containing desired state of lock
+     * @param boolean $locked Containing desired state of lock.
      *
      * @access public
      *

--- a/tests/unit/Pelagos/Entity/ResearchGroupTest.php
+++ b/tests/unit/Pelagos/Entity/ResearchGroupTest.php
@@ -441,9 +441,9 @@ class ResearchGroupTest extends TestCase
         $this->assertFalse($this->researchGroup->isLocked());
 
         // Test setting/checking lock and unlock.
-        $this->researchGroup->lock();
+        $this->researchGroup->setLocked(true);
         $this->assertTrue($this->researchGroup->isLocked());
-        $this->researchGroup->unlock();
+        $this->researchGroup->setLocked(false);
         $this->assertFalse($this->researchGroup->isLocked());
     }
 }


### PR DESCRIPTION
Had to add setLocked to entity, this is because the way PODS works. And used these functions for validation. And the form is only as smart to look for getters/setters/issers/hassers.