### PR TITLE
Display dates in UTC consistently.

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Resources/views/Dataland/summary.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/Dataland/summary.html.twig
@@ -131,13 +131,13 @@
                         {% if not dataset.datasetSubmission.temporalExtentBeginPosition|date('Y-m-d') |default %}
                             {% set begin = 'N/A' %}
                         {% else %}
-                            {% set begin = dataset.datasetSubmission.temporalExtentBeginPosition|date('Y-m-d') %}
+                            {% set begin = dataset.datasetSubmission.temporalExtentBeginPosition|date('Y-m-d', 'UTC') %}
                         {% endif %}
 
                         {% if not dataset.datasetSubmission.temporalExtentEndPosition|date('Y-m-d') |default %}
                             {% set end = 'N/A' %}
                         {% else %}
-                            {% set end = dataset.datasetSubmission.temporalExtentEndPosition|date('Y-m-d') %}
+                            {% set end = dataset.datasetSubmission.temporalExtentEndPosition|date('Y-m-d', 'UTC') %}
                         {% endif %}
 
                         <tr>


### PR DESCRIPTION
We display the temporalExtentBeginPosition (start date) and temporalExtentEndPosition (end date) as UTC in metadata already. This just makes it consistent on the Dataset landing data collection period start/end dates displayed.