### PR TITLE
Feature/pelagos 3754 prevent submission when research group is locked out

### DIFF
--- a/src/Pelagos/Bundle/AppBundle/Security/DatasetSubmissionVoter.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/DatasetSubmissionVoter.php
@@ -56,6 +56,11 @@ class DatasetSubmissionVoter extends PelagosEntityVoter
      */
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
     {
+        // If research group is locked, vote false.
+        if ($subject instanceof DatasetSubmission and true === $subject->getDataset()->getResearchGroup()->isLocked()) {
+            return false;
+        }
+
         $user = $token->getUser();
 
         // If the user token does not contain an Account, vote false.
@@ -70,7 +75,7 @@ class DatasetSubmissionVoter extends PelagosEntityVoter
 
         // A user with an account can only create or edit dataset submissions
         // associated with research groups that they (the user) are a member of.
-        
+
         $researchGroups = $user->getPerson()->getResearchGroups();
         if ($subject instanceof DatasetSubmission) {
             $submissionResearchGroup = $subject->getDataset()->getResearchGroup();

--- a/tests/unit/Pelagos/Bundle/AppBundle/Security/DatasetSubmissionVoterTest.php
+++ b/tests/unit/Pelagos/Bundle/AppBundle/Security/DatasetSubmissionVoterTest.php
@@ -91,6 +91,7 @@ class DatasetSubmissionVoterTest extends PelagosEntityVoterTest
                             ResearchGroup::class,
                             array(
                                 'isSameTypeAndId' => false,
+                                'isLocked' => false,
                             )
                         ),
                     )
@@ -123,6 +124,7 @@ class DatasetSubmissionVoterTest extends PelagosEntityVoterTest
                             ResearchGroup::class,
                             array(
                                 'isSameTypeAndId' => true,
+                                'isLocked' => false,
                             )
                         ),
                     )
@@ -172,6 +174,7 @@ class DatasetSubmissionVoterTest extends PelagosEntityVoterTest
                             ResearchGroup::class,
                             array(
                                 'isSameTypeAndId' => false,
+                                'isLocked' => false,
                             )
                         ),
                     )
@@ -221,6 +224,7 @@ class DatasetSubmissionVoterTest extends PelagosEntityVoterTest
                             ResearchGroup::class,
                             array(
                                 'isSameTypeAndId' => true,
+                                'isLocked' => false,
                             )
                         ),
                     )
@@ -262,6 +266,7 @@ class DatasetSubmissionVoterTest extends PelagosEntityVoterTest
                             ResearchGroup::class,
                             array(
                                 'isSameTypeAndId' => true,
+                                'isLocked' => false,
                             )
                         ),
                     )
@@ -276,6 +281,56 @@ class DatasetSubmissionVoterTest extends PelagosEntityVoterTest
                 $mockToken,
                 $datasetSubmission,
                 array(Voter::CAN_DELETE)
+            )
+        );
+    }
+
+    /**
+     * Test can create and edit for locked research group.
+     *
+     * Test if a user can NOT create a Dataset Submission for a dataset associated
+     * because the research group is locked.
+     *
+     * @return void
+     */
+    public function testCanNotCreateAndEditLockedResearchGroup()
+    {
+        $mockToken = $this->createMockToken();
+        $this->createMockPersonAssociation('ResearchGroup', $mockToken, RG_Roles::RESEARCHER);
+
+        $datasetSubmission = \Mockery::mock(
+            DatasetSubmission::class,
+            array(
+                'getDataset' => \Mockery::mock(
+                    Dataset::class,
+                    array(
+                        'getResearchGroup' => \Mockery::mock(
+                            ResearchGroup::class,
+                            array(
+                                'isSameTypeAndId' => false,
+                                'isLocked' => true,
+                            )
+                        ),
+                    )
+                ),
+                'getStatus' => DatasetSubmission::STATUS_INCOMPLETE,
+            )
+        );
+
+        $this->assertEquals(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote(
+                $mockToken,
+                $datasetSubmission,
+                array(Voter::CAN_CREATE)
+            )
+        );
+        $this->assertEquals(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote(
+                $mockToken,
+                $datasetSubmission,
+                array(Voter::CAN_EDIT)
             )
         );
     }


### PR DESCRIPTION
This is for of a precaution, than needed.