### PR TITLE
Bugfix/pelagos 3767 add expiration check to pelagos authenticator

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -36,7 +36,7 @@ parameters:
     ldap_bind_pw: ~
     ldap_people_ou: ou=members,ou=people,dc=griidc,dc=org
 
-    # The maximum age allowed for account passwords (as an ISO 8601 duration)
+    # The maximum age allowed for account passwords (as an ISO 8601 duration), 0 for no expiration.
     account_password_max_age: P180D
     # When to warn account holders of soon to expire passwords (as ISO 8601 durations)
     account_password_expiration_warn: [P7D, P1D]

--- a/app/config/routing_drupal.yml
+++ b/app/config/routing_drupal.yml
@@ -1,3 +1,3 @@
 _main:
     resource: routing.yml
-    prefix:   /%pelagos.prefix%
+    prefix:   "/%pelagos.prefix%"

--- a/app/config/routing_drupal_dev.yml
+++ b/app/config/routing_drupal_dev.yml
@@ -2,4 +2,4 @@
 
 _dev:
     resource: routing_dev.yml
-    prefix:   /%pelagos.prefix%
+    prefix:   "/%pelagos.prefix%"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -122,6 +122,8 @@ services:
     pelagos.security.login_form_authenticator:
         class: Pelagos\Bundle\AppBundle\Security\LoginFormAuthenticator
         autowire: true
+        arguments:
+            $maxPwAge: "%account_password_max_age%"
         tags:
             - { name: monolog.logger, channel: login_attempts }
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -123,7 +123,7 @@ services:
         class: Pelagos\Bundle\AppBundle\Security\LoginFormAuthenticator
         autowire: true
         arguments:
-            $maxPwAge: "%account_password_max_age%"
+            $maximumPasswordAge: "%account_password_max_age%"
         tags:
             - { name: monolog.logger, channel: login_attempts }
 

--- a/src/Pelagos/Bundle/AppBundle/Controller/UI/AccountController.php
+++ b/src/Pelagos/Bundle/AppBundle/Controller/UI/AccountController.php
@@ -189,6 +189,31 @@ class AccountController extends UIController implements OptionalReadOnlyInterfac
     }
 
     /**
+     * The page for changing the password when it's expired.
+     *
+     * @Route("/account/password-expired")
+     * @Method("GET")
+     *
+     * @return Response A Response instance.
+     */
+    public function passwordExpiredAction()
+    {
+        // If the user is not authenticated.
+        if (!$this->isGranted('IS_AUTHENTICATED_FULLY')) {
+            // The token must be bad or missing.
+            return $this->render('PelagosAppBundle:template:InvalidToken.html.twig');
+        }
+
+        // Send back the set password screen.
+        return $this->render(
+            'PelagosAppBundle:Account:setExpiredPassword.html.twig',
+            array(
+                'personToken' => $this->getUser()->getPerson()->getToken(),
+            )
+        );
+    }
+
+    /**
      * Redirect GET sent to this route.
      *
      * @Route("/account/create")

--- a/src/Pelagos/Bundle/AppBundle/Resources/views/Account/setExpiredPassword.html.twig
+++ b/src/Pelagos/Bundle/AppBundle/Resources/views/Account/setExpiredPassword.html.twig
@@ -1,0 +1,43 @@
+{% extends "PelagosAppBundle:template:UI.html.twig" %}
+
+{% block javascripts %}
+    {{ parent() }}
+    
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/xregexp/2.0.0/xregexp-all-min.js"></script>
+    
+    <script type="text/javascript" src="{{ asset('build/js/Account.js') }}"></script>
+{% endblock %}
+
+{% block body %}
+    <div class="messages warning">
+        <h2 class="element-invisible">Status message</h2>
+        Your password has expired. Please set a new password.
+    </div>
+    <form id="passwordForm" method="post" action="{{ path('pelagos_app_ui_account_create') }}?person_token={{ personToken.getTokenText }}">
+    <p>
+        Please create a password.
+    </p>
+    <label for="password">New Password:</label>
+    <input type="password" id="password" name="password" size="40" required>&nbsp;
+    <label style="display:inline;" for="password" class="error"></label>
+    <p>
+        <label for="verify_password">Verify Password:</label>
+        <input type="password" id="verify_password" name="verify_password" size="40">&nbsp;
+        <label style="display:inline;" for="verify_password" class="error"></label>
+    </p>
+    <p>
+        <ul>
+            <li>Passwords must be a minimum of eight characters/numerals.</li>
+            <li>Passwords must contain a combination of three of the the following:
+                <ul>
+                    <li>Upper Case Letters (A, B, C, etc...)</li>
+                    <li>Lower Case Letters (a, b, c, etc...)</li>
+                    <li>Numbers (1, 2, 3, etc...)</li>
+                    <li>Non-Alphabetic Characters (!, @, #, etc...)</li>
+                </ul>
+            </li>
+        </ul>
+    </p>
+    <button type="submit">Next</button>
+    </form>
+{% endblock %}

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -78,7 +78,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
      * @param EntityManagerInterface $entityManager An Entity Manager.
      * @param RouterInterface        $router        A Router.
      * @param LoggerInterface        $logger        A Monolog logger.
-     * @param string                 $maxPwAge      The max age for password paramater.
+     * @param string                 $maxPwAge      The max age for password parameter.
      */
     public function __construct(
         FormFactoryInterface $formFactory,

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -264,8 +264,10 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
     /**
      * Return to login page and add destination for redirect.
      *
-     * @param Request                 $request   A Symfony Request, req by interface.
-     * @param AuthenticationException $exception The exception thrown.
+     * @param Request                  $request   A Symfony Request, req by interface.
+     * @param AuthenticationException  $exception The exception thrown.
+     *
+     * @throws AuthenticationException When the user is not found, and credentials is invalid.
      *
      * @return Response The response or null to continue request.
      */

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -24,6 +24,7 @@ use Pelagos\Bundle\AppBundle\Form\LoginForm;
 
 use Pelagos\Entity\Account;
 use Pelagos\Entity\LoginAttempts;
+use Pelagos\Entity\Password;
 use Pelagos\Entity\Person;
 
 /**
@@ -64,6 +65,13 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
     protected $logger;
 
     /**
+     * String describing max PW age.
+     *
+     * @var string maxPwAge
+     */
+    protected $maxPwAge;
+
+    /**
      * Class constructor for Dependency Injection.
      *
      * @param FormFactoryInterface   $formFactory   A Form Factory.
@@ -75,12 +83,14 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
         FormFactoryInterface $formFactory,
         EntityManagerInterface $entityManager,
         RouterInterface $router,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        string $maxPwAge
     ) {
         $this->formFactory = $formFactory;
         $this->entityManager = $entityManager;
         $this->router = $router;
         $this->logger = $logger;
+        $this->maxPwAge = $maxPwAge;
     }
 
     /**
@@ -151,6 +161,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
      *
      * @throws AuthenticationException When account is locked out.
      * @throws AuthenticationException When this is a bad password.
+     * @throws AuthenticationException When this is an expired password.
      *
      * @return bool True if the credentials are valid.
      */
@@ -159,6 +170,12 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
         // Here check to see if $user is locked out?
         if ($user->isLockedOut()) {
             throw new AuthenticationException('Too many login attempts');
+        }
+
+        // Here check to see if $user has expired password.
+        $passwordObj = $user->getPasswordEntity();
+        if (false) {
+            throw new AuthenticationException('Password is expired.');
         }
 
         $this->userAttempt($user);

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -85,7 +85,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
         EntityManagerInterface $entityManager,
         RouterInterface $router,
         LoggerInterface $logger,
-        $maximumPasswordAge
+        ? string $maximumPasswordAge
     ) {
         $this->formFactory = $formFactory;
         $this->entityManager = $entityManager;

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -173,15 +173,16 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
             throw new AuthenticationException('Too many login attempts');
         }
 
-        // Check for expired password.
-        if ($this->checkIfPasswordExpired($user->getPasswordEntity())) {
-            throw new AuthenticationException('Password is expired.');
-        }
 
         $this->userAttempt($user);
 
         $password = $credentials['_password'];
+        // Check that password is correct.
         if ($user->getPasswordEntity()->comparePassword($password)) {
+            // Since password is correct, now check for expired password.
+            if ($this->checkIfPasswordExpired($user->getPasswordEntity())) {
+                throw new AuthenticationException('Password is expired.');
+            }
             return true;
         } else {
             throw new AuthenticationException('Invalid Credentials');

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -264,8 +264,8 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
     /**
      * Return to login page and add destination for redirect.
      *
-     * @param Request                  $request   A Symfony Request, req by interface.
-     * @param AuthenticationException  $exception The exception thrown.
+     * @param Request                 $request   A Symfony Request, req by interface.
+     * @param AuthenticationException $exception The exception thrown.
      *
      * @throws AuthenticationException When the user is not found, and credentials is invalid.
      *
@@ -274,7 +274,6 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
         if ($exception->getMessage() == 'Password is expired.') {
-
             $credentials = $this->getCredentials($request);
             $username = $credentials['_username'];
 
@@ -299,7 +298,12 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
             $personToken = new PersonToken($person, 'PASSWORD_EXPIRED', new \DateInterval('PT1H'));
             $this->entityManager->persist($personToken);
             $this->entityManager->flush();
-            $url = $this->router->generate('pelagos_app_ui_account_passwordexpired', array('person_token' => $person->getToken()->getTokenText()));
+            $url = $this->router->generate(
+                'pelagos_app_ui_account_passwordexpired',
+                array(
+                    'person_token' => $person->getToken()->getTokenText()
+                )
+            );
         } else {
             $destination = $request->query->get('destination');
             $request->getSession()->set(Security::AUTHENTICATION_ERROR, $exception);

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -67,31 +67,31 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
     /**
      * String describing max PW age.
      *
-     * @var string maxPwAge
+     * @var string maximumPasswordAge
      */
-    protected $maxPwAge;
+    protected $maximumPasswordAge;
 
     /**
      * Class constructor for Dependency Injection.
      *
-     * @param FormFactoryInterface   $formFactory   A Form Factory.
-     * @param EntityManagerInterface $entityManager An Entity Manager.
-     * @param RouterInterface        $router        A Router.
-     * @param LoggerInterface        $logger        A Monolog logger.
-     * @param string                 $maxPwAge      The max age for password parameter.
+     * @param FormFactoryInterface   $formFactory        A Form Factory.
+     * @param EntityManagerInterface $entityManager      An Entity Manager.
+     * @param RouterInterface        $router             A Router.
+     * @param LoggerInterface        $logger             A Monolog logger.
+     * @param string                 $maximumPasswordAge The max age for password parameter.
      */
     public function __construct(
         FormFactoryInterface $formFactory,
         EntityManagerInterface $entityManager,
         RouterInterface $router,
         LoggerInterface $logger,
-        string $maxPwAge
+        string $maximumPasswordAge
     ) {
         $this->formFactory = $formFactory;
         $this->entityManager = $entityManager;
         $this->router = $router;
         $this->logger = $logger;
-        $this->maxPwAge = $maxPwAge;
+        $this->maximumPasswordAge = $maximumPasswordAge;
     }
 
     /**
@@ -199,7 +199,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
     {
         // Check for expired password.
         $now = new \DateTime('now');
-        $expiration = $password->getModificationTimeStamp()->add(new \DateInterval($this->maxPwAge));
+        $expiration = $password->getModificationTimeStamp()->add(new \DateInterval($this->maximumPasswordAge));
         // If the current timestamp is past the calculated expiration timestamp, the password has expired.
         return ($now > $expiration);
     }

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -85,18 +85,13 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
         EntityManagerInterface $entityManager,
         RouterInterface $router,
         LoggerInterface $logger,
-        string $maximumPasswordAge
+        $maximumPasswordAge
     ) {
         $this->formFactory = $formFactory;
         $this->entityManager = $entityManager;
         $this->router = $router;
         $this->logger = $logger;
-        // Set attribute to 0 if null in constructor.
-        if (null === $maximumPasswordAge) {
-            $this->maximumPasswordAge = 0;
-        } else {
-            $this->maximumPasswordAge = $maximumPasswordAge;
-        }
+        $this->maximumPasswordAge = $maximumPasswordAge;
     }
 
     /**
@@ -205,7 +200,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
     {
         $passwordIsExpired = true;
         // If parameter is missing or set to 0, passwords do not expire.
-        if (0 === $this->maximumPasswordAge) {
+        if (empty($this->maximumPasswordAge)) {
             $passwordIsExpired = false;
         } else {
             // Check for expired password.

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -174,10 +174,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
         }
 
         // Check for expired password.
-        $now = new \DateTime('now');
-        $expiration = $user->getPasswordEntity()->getModificationTimeStamp()->add(new \DateInterval($this->maxPwAge));
-        // If today is past the expiration date, the milk is sour.
-        if ($now > $expiration) {
+        if ($this->checkIfPasswordExpired($user->getPasswordEntity())) {
             throw new AuthenticationException('Password is expired.');
         }
 
@@ -189,6 +186,22 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
         } else {
             throw new AuthenticationException('Invalid Credentials');
         }
+    }
+
+    /**
+     * Checks if a Password object is expired.
+     *
+     * @param password $password The Password object that may or may not be expired.
+     *
+     * @return bool True if expired, false otherwise.
+     */
+    protected function checkIfPasswordExpired(password $password)
+    {
+        // Check for expired password.
+        $now = new \DateTime('now');
+        $expiration = $password->getModificationTimeStamp()->add(new \DateInterval($this->maxPwAge));
+        // If the current timestamp is past the calculated expiration timestamp, the password has expired.
+        return ($now > $expiration);
     }
 
     /**

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -273,14 +273,14 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        if ($exception->getMessage() == 'Password is expired.') {
+        if ($exception->getMessage() === 'Password is expired.') {
             $credentials = $this->getCredentials($request);
             $username = $credentials['_username'];
 
             $user = $this->entityManager->getRepository(Account::class)
                 ->findOneBy(['userId' => $username]);
 
-            if (null == $user) {
+            if (null === $user) {
                 throw new AuthenticationException('Invalid Credentials');
             }
 

--- a/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
+++ b/src/Pelagos/Bundle/AppBundle/Security/LoginFormAuthenticator.php
@@ -78,6 +78,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
      * @param EntityManagerInterface $entityManager An Entity Manager.
      * @param RouterInterface        $router        A Router.
      * @param LoggerInterface        $logger        A Monolog logger.
+     * @param string                 $maxPwAge      The max age for password paramater.
      */
     public function __construct(
         FormFactoryInterface $formFactory,
@@ -172,9 +173,11 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
             throw new AuthenticationException('Too many login attempts');
         }
 
-        // Here check to see if $user has expired password.
-        $passwordObj = $user->getPasswordEntity();
-        if (false) {
+        // Check for expired password.
+        $now = new \DateTime('now');
+        $expiration = $user->getPasswordEntity()->getModificationTimeStamp()->add(new \DateInterval($this->maxPwAge));
+        // If today is past the expiration date, the milk is sour.
+        if ($now > $expiration) {
             throw new AuthenticationException('Password is expired.');
         }
 


### PR DESCRIPTION
To test, connect to database and find your person_id from the account table, then update the latest password modification date by that username so that it is more than 6 months ago. Try logging in. Set it back. Try logging in again.

ex: 
SQL> SELECT account_id FROM account WHERE user_id = 'mwilliamson';
10009

SQL> \x
SQL>SELECT * FROM password WHERE account_id = 10009;
...lots of records...use highest ID one.
id                      | 1917
...
modification_time_stamp | 2019-05-06 15:45:21-05

SQL>UPDATE password SET modification_time_stamp = '2019-03-06 15:45:21-05' WHERE id = 1917;

