### PR TITLE
ID must by cast to int, because RabbitPublisher does not seem to like…

### DIFF
--- a/src/Consumer/DatasetSubmissionConsumer.php
+++ b/src/Consumer/DatasetSubmissionConsumer.php
@@ -182,6 +182,6 @@ class DatasetSubmissionConsumer implements ConsumerInterface
         // Log processing complete.
         $this->logger->info('Dataset file processing complete', $loggingContext);
         // Publish an AMQP message to trigger dataset file hashing.
-        $this->publisher->publish($datasetSubmission->getId(), RabbitPublisher::FILE_HASHER_PRODUCER);
+        $this->publisher->publish((int)$datasetSubmission->getId(), RabbitPublisher::FILE_HASHER_PRODUCER);
     }
 }

--- a/src/Consumer/DatasetSubmissionConsumer.php
+++ b/src/Consumer/DatasetSubmissionConsumer.php
@@ -182,6 +182,6 @@ class DatasetSubmissionConsumer implements ConsumerInterface
         // Log processing complete.
         $this->logger->info('Dataset file processing complete', $loggingContext);
         // Publish an AMQP message to trigger dataset file hashing.
-        $this->publisher->publish((int)$datasetSubmission->getId(), RabbitPublisher::FILE_HASHER_PRODUCER);
+        $this->publisher->publish((int) $datasetSubmission->getId(), RabbitPublisher::FILE_HASHER_PRODUCER);
     }
 }

--- a/templates/Email/data-managers.dataset-submitted.email.twig
+++ b/templates/Email/data-managers.dataset-submitted.email.twig
@@ -4,7 +4,7 @@
     {% set submitterGroupsAndRepos = dataset.datasetSubmission.submitter.dataRepositoryNames | merge(dataset.datasetSubmission.submitter.researchGroupNames) %}
     Dear {{ recipient.firstName }} {{ recipient.lastName }},<br>
     <br>
-    A dataset has been submitted to the Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} for the dataset {{dataset.udi}}. This dataset has been assigned the doi:{{dataset.doi.doi}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ submitterGroupsAndRepos | join (', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.<br>
+    A dataset has been submitted to the Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} for the dataset {{dataset.udi}}. This dataset has been assigned the doi:{{dataset.doi}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ submitterGroupsAndRepos | join (', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.<br>
     <br>
     Thank you,<br>
     <br>
@@ -17,7 +17,7 @@
     {% set submitterGroupsAndRepos = dataset.datasetSubmission.submitter.researchGroupNames | merge(dataset.datasetSubmission.submitter.dataRepositoryNames) %}
 Dear {{ recipient.firstName }} {{ recipient.lastName }},
 
-A dataset has been submitted to the Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} for the dataset {{dataset.udi}}. This dataset has been assigned the doi:{{dataset.doi.doi}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ submitterGroupsAndRepos | join (', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.
+A dataset has been submitted to the Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC) by {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} for the dataset {{dataset.udi}}. This dataset has been assigned the doi:{{dataset.doi}}. {{dataset.datasetSubmission.submitter.firstName}} {{dataset.datasetSubmission.submitter.lastName}} is a member of {{ submitterGroupsAndRepos | join (', ') }} and the dataset is associated with {{dataset.researchGroup.name}}.
 
 Thank you,
 


### PR DESCRIPTION
… the "object" being send. And crashes.