### PR TITLE
Fixed setting back base url

### DIFF
--- a/src/Util/RouterModifier.php
+++ b/src/Util/RouterModifier.php
@@ -90,7 +90,6 @@ class RouterModifier implements RouterInterface
             $context = $this->getContext();
             $context->setBaseUrl($oldBaseUrl);
             $context = $this->setContext((string) $context);
-
         } else {
             $generate = $this->innerRouter->generate($name, $parameters, $referenceType);
         }

--- a/src/Util/RouterModifier.php
+++ b/src/Util/RouterModifier.php
@@ -82,14 +82,14 @@ class RouterModifier implements RouterInterface
     {
         if (in_array($name, $this->excludeRoutes)) {
             $context = $this->getContext();
-            $oldBaseUrl = $context->getBaseUrl();
+            $oldBaseUrl = (string) $context->getBaseUrl();
             $context->setBaseUrl('');
             $context = $this->setContext($context);
             $generate = $this->innerRouter->generate($name, $parameters, $referenceType);
             // Set the baseUrl back in context.
             $context = $this->getContext();
             $context->setBaseUrl($oldBaseUrl);
-            $context = $this->setContext((string) $context);
+            $context = $this->setContext($context);
         } else {
             $generate = $this->innerRouter->generate($name, $parameters, $referenceType);
         }

--- a/src/Util/RouterModifier.php
+++ b/src/Util/RouterModifier.php
@@ -82,11 +82,15 @@ class RouterModifier implements RouterInterface
     {
         if (in_array($name, $this->excludeRoutes)) {
             $context = $this->getContext();
-            $oldContext = $context;
+            $oldBaseUrl = $context->getBaseUrl();
             $context->setBaseUrl('');
             $context = $this->setContext($context);
             $generate = $this->innerRouter->generate($name, $parameters, $referenceType);
-            $context = $this->setContext($oldContext);
+            // Set the baseUrl back in context.
+            $context = $this->getContext();
+            $context->setBaseUrl($oldBaseUrl);
+            $context = $this->setContext((string) $context);
+
         } else {
             $generate = $this->innerRouter->generate($name, $parameters, $referenceType);
         }


### PR DESCRIPTION
Because I was using $context by reference, setting it back just basically double set it.
Now storing the baseUrl, re-getting the context, changing it again with explicit string cast and now it's working.