### PR TITLE
Wrap strings with gco:CharacterString in XML.

### DIFF
--- a/templates/MetadataGenerator/MD_Distribution.xml.twig
+++ b/templates/MetadataGenerator/MD_Distribution.xml.twig
@@ -196,10 +196,10 @@
                                         <gco:CharacterString>{{ link.protocol  }}</gco:CharacterString>
                                     </gmd:protocol>
                                     <gmd:name>
-                                        {{ link.name }}
+                                        <gco:CharacterString>{{ link.name  }}</gco:CharacterString>
                                     </gmd:name>
                                     <gmd:description>
-                                        {{ link.description }}
+                                        <gco:CharacterString>{{ link.description  }}</gco:CharacterString>
                                     </gmd:description>
                                     <gmd:function>
                                         <gmd:CI_OnLineFunctionCode


### PR DESCRIPTION
Now validates, confirmed in Oxygen 20.1