### PR TITLE
Add citation to mdgen template.

### DIFF
--- a/templates/MetadataGenerator/MD_DataIdentification.xml.twig
+++ b/templates/MetadataGenerator/MD_DataIdentification.xml.twig
@@ -72,6 +72,13 @@
             }
         %}
     </gmd:descriptiveKeywords>
+    <gmd:resourceConstraints xlink:title="Cite As">
+        <gmd:MD_Constraints>
+            <gmd:useLimitation>
+                <gco:CharacterString><![CDATA[{{dataset.citation}}]]></gco:CharacterString>
+            </gmd:useLimitation>
+        </gmd:MD_Constraints>
+    </gmd:resourceConstraints>
     <gmd:resourceConstraints xlink:title="CC0 License">
         <gmd:MD_LegalConstraints>
             <gmd:useConstraints>
@@ -88,13 +95,6 @@
                 <gco:CharacterString>All materials on this website are made available to GRIIDC and in turn to you "as-is." Content may only be submitted by an individual who represents and warrants that s/he has sufficient rights to be able to make the content available under a CC0 waiver. There is no warranty (expressed or implied) to these materials, their title, accuracy, non-infringement of third party rights, or fitness for any particular purpose, including the performance or results you may obtain from their use. Use these materials at your own risk.  Under no circumstances shall GRIIDC be liable for any direct, incidental, special, consequential, indirect, or punitive damages that result from the use or the inability to use either this website or the materials available via this website. If you are dissatisfied with any website feature, content, or terms of use, your sole and exclusive remedy is to discontinue use.</gco:CharacterString>
             </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
-    </gmd:resourceConstraints>
-    <gmd:resourceConstraints xlink:title="Cite As">
-        <gmd:MD_Constraints>
-            <gmd:useLimitation>
-                <gco:CharacterString><![CDATA[{{dataset.citation}}]]></gco:CharacterString>
-            </gmd:useLimitation>
-        </gmd:MD_Constraints>
     </gmd:resourceConstraints>
     <gmd:language>
         <gco:CharacterString>eng; USA</gco:CharacterString>

--- a/templates/MetadataGenerator/MD_DataIdentification.xml.twig
+++ b/templates/MetadataGenerator/MD_DataIdentification.xml.twig
@@ -89,6 +89,13 @@
             </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
     </gmd:resourceConstraints>
+    <gmd:resourceConstraints xlink:title="Cite As">
+        <gmd:MD_Constraints>
+            <gmd:useLimitation>
+                <gco:CharacterString><![CDATA[{{dataset.citation}}]]></gco:CharacterString>
+            </gmd:useLimitation>
+        </gmd:MD_Constraints>
+    </gmd:resourceConstraints>
     <gmd:language>
         <gco:CharacterString>eng; USA</gco:CharacterString>
     </gmd:language>


### PR DESCRIPTION
![Screenshot from 2020-04-22 16-04-18](https://user-images.githubusercontent.com/15313486/80033884-12582380-84b3-11ea-8e98-805b224852a6.png)
Included screenshot of validation.

This simply calls dataset's getCitation method, and if that method is made to call the upcoming new citation-generating utility, this won't need to be modified later.