### PR TITLE
Removed ERDDAP generated section.

### DIFF
--- a/src/Entity/DatasetLink.php
+++ b/src/Entity/DatasetLink.php
@@ -50,7 +50,7 @@ class DatasetLink extends Entity
     const LINK_NAME_CODES = [
         'erddap' => [
             'name' => 'ERDDAP',
-            'description' => 'An ERDDAP link.',
+            'description' => "ERDDAP's version of the OPeNDAP .html web page for this dataset. Specify a subset of the dataset and download the data via OPeNDAP or in many different file types.",
         ],
         'ncei' => [
             'name' => 'NCEI',

--- a/templates/MetadataGenerator/MD_Distribution.xml.twig
+++ b/templates/MetadataGenerator/MD_Distribution.xml.twig
@@ -152,38 +152,8 @@
                     </gmd:onLine>
                 </gmd:MD_DigitalTransferOptions>
             </gmd:distributorTransferOptions>
-            {% if dataset.datasetSubmission.erddapUrl %}
-                <gmd:distributorTransferOptions>
-                    <gmd:MD_DigitalTransferOptions>
-                        <gmd:onLine>
-                            <gmd:CI_OnlineResource>
-                                <gmd:linkage>
-                                    <gmd:URL>{{ dataset.datasetSubmission.erddapUrl }}</gmd:URL>
-                                </gmd:linkage>
-                                <gmd:protocol>
-                                    <gco:CharacterString>{{ dataset.datasetSubmission.erddapUrlProtocol  }}</gco:CharacterString>
-                                </gmd:protocol>
-                                <gmd:name>
-                                    ERDDAP Data Subset Form
-                                </gmd:name>
-                                <gmd:description>
-                                    ERDDAP's version of the OPeNDAP .html web page for this dataset.
-                                    Specify a subset of the dataset and download the data via OPeNDAP
-                                    or in many different file types.
-                                </gmd:description>
-                                <gmd:function>
-                                    <gmd:CI_OnLineFunctionCode
-                                            codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
-                                            codeListValue="download" codeSpace="001">
-                                        download
-                                    </gmd:CI_OnLineFunctionCode>
-                                </gmd:function>
-                            </gmd:CI_OnlineResource>
-                        </gmd:onLine>
-                    </gmd:MD_DigitalTransferOptions>
-                </gmd:distributorTransferOptions>
-            {% endif %}
             {% if dataset.datasetSubmission.datasetLinks %}
+                {% set linkcodes = constant('App\\Entity\\DatasetLink::ONLINE_FUNCTION_CODES') %}
                 {% for link in dataset.datasetSubmission.datasetLinks %}
                     <gmd:distributorTransferOptions>
                         <gmd:MD_DigitalTransferOptions>
@@ -204,7 +174,7 @@
                                     <gmd:function>
                                         <gmd:CI_OnLineFunctionCode
                                                 codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
-                                                codeListValue="{{ link.functionCode }}" codeSpace="001">
+                                                codeListValue="{{ link.functionCode }}" codeSpace="{{ attribute(linkcodes[link.functionCode], 'code') }}">
                                                 {{ link.functionCode }}
                                         </gmd:CI_OnLineFunctionCode>
                                     </gmd:function>


### PR DESCRIPTION
Also captured the old description in the LINK_NAME_CODES for preservation. (Not currently used).
Fixed codeSpace it would have been always 001.