### PR TITLE
Texas A&M University–Corpus Christi

### DIFF
--- a/templates/Account/Account.html.twig
+++ b/templates/Account/Account.html.twig
@@ -2,7 +2,7 @@
 
 {% block javascripts %}
     {{ parent() }}
-    
+
     <script type="text/javascript" src="{{ asset('build/js/Account.js') }}"></script>
 {% endblock %}
 
@@ -27,7 +27,7 @@
         </tr>
         <tr>
             <td width="50%">
-                Accounts are governed by rules of Texas A&M University-Corpus Christi. Accounts are issued to individuals and shall not be shared.</br>
+                Accounts are governed by rules of Texas A&M University–Corpus Christi. Accounts are issued to individuals and shall not be shared.</br>
                 <ul>
                     <li>Unauthorized use is prohibited.</li>
                     <li>Usage may be subject to security testing and monitoring.</li>

--- a/templates/Security/login.html.twig
+++ b/templates/Security/login.html.twig
@@ -64,10 +64,10 @@
                 </div>
                 <div id="sidebar">
                     <p class="fl-panel fl-note fl-bevel-white fl-font-size-80">You have reached the GRIIDC site.</p>
-                    <p>Accounts are governed by rules of Texas A&M University-Corpus Christi. Accounts are issued to individuals and shall not be shared.</p>
+                    <p>Accounts are governed by rules of Texas A&M University–Corpus Christi. Accounts are issued to individuals and shall not be shared.</p>
                     <p>User authentication is required to access these pages.</p>
                     <p>If you need to access GRIIDC pages and are not a registered user, please <a href="{{ path('pelagos_app_ui_account_default') }}">request an account</a>.</p>
-                    <p>Texas A&amp;M University-Corpus Christi</p>
+                    <p>Texas A&amp;M University–Corpus Christi</p>
                     <ul>
                         <li>Unauthorized use is prohibited.</li>
                         <li>Usage may be subject to security testing and monitoring.</li>


### PR DESCRIPTION
We've no doubt got a bunch of these in Drupal as well, but all references to Texas A&M University–Corpus Christi should use the endash character without any spaces between University and Corpus. 

I'd of erroneously been using a normal dash '-' instead of the correct endash '–' all this time, which is between the shortest dash '-' and longest emdash '—' in length.