### PR TITLE
Fixed layout for people tab cards

### DIFF
--- a/assets/js/vue/ResearchGroupApp.vue
+++ b/assets/js/vue/ResearchGroupApp.vue
@@ -85,7 +85,5 @@
 </script>
 
 <style scoped>
-    .main-card {
-        overflow-y: scroll;
-    }
+
 </style>

--- a/assets/js/vue/components/research-group/PeopleTab.vue
+++ b/assets/js/vue/components/research-group/PeopleTab.vue
@@ -25,7 +25,7 @@
 </script>
 
 <style scoped>
-    .card-product {
-        margin-top: 10px;
+    .card-columns {
+        column-gap: 1rem !important;
     }
 </style>


### PR DESCRIPTION
Layout for cards on People tab was inconsistent for research groups which had more people associated with it. This branch is the fix for it