### PR TITLE
Added URI to search results.

### DIFF
--- a/assets/js/vue/components/search/DatasetRow.vue
+++ b/assets/js/vue/components/search/DatasetRow.vue
@@ -44,7 +44,7 @@
         },
         data: function () {
             return {
-                url: Routing.generate("pelagos_app_ui_dataland_default", {'udi' : this.datasetRowData.udi } )
+                url: this.datasetRowData.uri
             }
         },
         methods: {

--- a/src/Controller/UI/SearchPageController.php
+++ b/src/Controller/UI/SearchPageController.php
@@ -6,6 +6,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 use App\Entity\Account;
 use App\Event\LogActionItemEventDispatcher;
@@ -64,7 +65,13 @@ class SearchPageController extends AbstractController
         $buildQuery = $searchUtil->buildQuery($requestParams);
         $resultsBeforeHydration = $searchUtil->findDatasets($buildQuery);
         foreach ($resultsBeforeHydration as $result) {
-            array_push($results, $result->getResult()->getHit()['_source']);
+            $resultData = $result->getResult()->getData();
+            $resultData['uri'] = $this->generateUrl(
+                'pelagos_app_ui_dataland_default',
+                ['udi' => $resultData['udi']],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
+            array_push($results, $resultData);
         }
         $count = $searchUtil->getCount($buildQuery);
         $researchGroupsInfo = $searchUtil->getResearchGroupAggregations($buildQuery);


### PR DESCRIPTION
Because the URL comes from the FOS router, and the FOS router has a base path set that can not be manipulated without causing other issues, I added the URI to the search result. This is always a good Rest thing to do, to show the resource for your result.