### PR TITLE
Enable basic homepage for nasgrp.

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,7 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     homedir_prefix: '%env(HOMEDIR_PREFIX)%'
+    custom_template: '%env(CUSTOM_BASE_TEMPLATE)%'
     locale: en
     router.request_context.host: "%env(HOSTNAME)%"
     router.request_context.scheme: "https"

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -24,13 +24,13 @@ class DefaultController extends AbstractController
      */
     public function index()
     {
-        if ($this->getParameter('kernel.debug')) {
+        if ($this->getParameter('kernel.debug') or (!empty($this->getParameter('custom_template')))) {
             return $this->render('Default/index.html.twig');
         } else {
             return $this->redirect('/', 302);
         }
     }
-    
+
     /**
      * The admin action.
      *


### PR DESCRIPTION
We need something now because we don't have Drupal handling our default route for nasgrp. What is in the controller now results in a re-direct loop, and I think it simply never gets there in griidc mode because Drupal handles it first.