### PR TITLE
Bugfix/pelagos 4120 downloader use testfile.bin in public dir

### DIFF
--- a/assets/static/js/download.js
+++ b/assets/static/js/download.js
@@ -89,7 +89,7 @@ function testDownload(fileSize) {
     let start = new Date().getTime();
     $.ajax({
         type: "GET",
-        "url": Routing.getBaseUrl() + "/images/testfile.bin?id=" + start,
+        "url": Routing.getBaseUrl() + "/testfile.bin?id=" + start,
         success: function(msg) {
             end = new Date().getTime();
             diff = (end - start) / 1000;


### PR DESCRIPTION
I ended up just copying testfile.bin into public and adjusting the route accordingly.