### PR TITLE
Add additional details to remotely hosted failure report.

### DIFF
--- a/templates/Email/data-repository-managers.error-remotely-hosted.email.twig
+++ b/templates/Email/data-repository-managers.error-remotely-hosted.email.twig
@@ -2,21 +2,23 @@
 
 {% block body_html %}
     <h3>
-        Below are the list of Dataset Udi's which have failed.
+        Below are the list of Dataset UDIs and remote links which have failed.
     </h3>
 
     <br>
 
-    {% for udi in listOfUdi %}
-        <li>{{ udi }}</li>
+    {% for error in errors %}
+
+    <li><a href={{ url('pelagos_app_ui_dataland_default', { 'udi': error.udi }) }}>{{ error.udi }}</a> - {{ error.link }}</li>
     {% endfor %}
 {% endblock %}
 
 {% block body_text %}
 
-Below are the list of Dataset Udi's which have failed.
+Below are the list of Dataset UDIs and remote links which have failed.
 
-    {% for udi in listOfUdi %}
-        {{ udi }}
-    {% endfor %}
+{% for error in errors %}
+{{ url('pelagos_app_ui_dataland_default', {'udi': error.udi }) }} - {{ error.link }}
+{% endfor %}
+
 {% endblock %}


### PR DESCRIPTION
To test, make sure and insert a bad URL in an active remote dataset submission.

i.e.
update dataset_submission set dataset_file_uri = 'https://www.tamucc.edu/data/R4.x257.229:0003'  where id = 11092; # works with current dump, ymmv.