### PR TITLE
Feature/pelagos 4583 add api to get global ingest directories

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -99,6 +99,9 @@ services:
         $doiApiPassword: "%env(DOI_API_PASSWORD)%"
         $doiApiPrefix: "%env(DOI_API_PREFIX)%"
         $doiApiUrl: "%env(DOI_API_URL)%"
+    
+    App\Util\IngestUtil:
+        $ingestApiUrl: "%env(INGEST_API_URL)%"
 
     App\Util\Ldap\Ldap:
         $ldapBindDn: "%env(LDAP_BIND_DN)%"

--- a/src/Controller/Api/DatasetSubmissionController.php
+++ b/src/Controller/Api/DatasetSubmissionController.php
@@ -19,7 +19,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
+use App\Entity\Account;
 use App\Entity\File;
 use App\Entity\DatasetSubmission;
 use App\Entity\Fileset;
@@ -422,7 +424,9 @@ class DatasetSubmissionController extends EntityController
      */
     public function getGlobalIngestFolders(IngestUtil $ingestUtil): Response
     {
-        $username = 'kthyng';
-        return $this->makeJsonResponse($ingestUtil->getUsersIngestFoldersInIncomingDir($username));
+        if (!($this->getUser() instanceof Account)) {
+            throw new AccessDeniedException('User is either not logged in or does not have an account');
+        }
+        return $this->makeJsonResponse($ingestUtil->getUsersIngestFoldersInIncomingDir($this->getUser()->getUserID()));
     }
 }

--- a/src/Controller/Api/DatasetSubmissionController.php
+++ b/src/Controller/Api/DatasetSubmissionController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api;
 
 use App\Util\FileUploader;
 use App\Util\FolderStructureGenerator;
+use App\Util\IngestUtil;
 
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -419,17 +420,9 @@ class DatasetSubmissionController extends EntityController
      *
      * @return Response
      */
-    public function getGlobalIngestFolders(): Response
+    public function getGlobalIngestFolders(IngestUtil $ingestUtil): Response
     {
-        $user = $this->getUser();
-        /* TODO */
-        return $this->makeJsonResponse([
-            ".dotfolder",
-            "H1.x123.456.7890",
-            "H1.x123.456:7891",
-            "R2.x137.108.0003",
-            "Spaces in foldername",
-            "c1.x123.456:7890"
-        ]);
+        $username = 'kthyng';
+        return $this->makeJsonResponse($ingestUtil->getUsersIngestFoldersInIncomingDir($username));
     }
 }

--- a/src/Util/IngestUtil.php
+++ b/src/Util/IngestUtil.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Util;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\ServerException;
+
+use App\Exception\HttpClientErrorException;
+use App\Exception\HttpServerErrorException;
+
+/**
+ * A utility query the Ingest server API.
+ */
+class IngestUtil
+{
+    /**
+     * The url for the API.
+     *
+     * @var string
+     */
+    private $url;
+
+    /**
+     * Constructor.
+     *
+     */
+    public function __construct()
+    {
+        $this->url = 'http://griidc-ingest.tamucc.edu:3000/getFolders';
+    }
+
+    /**
+     * This function will get a listing of ingest folders.
+     *
+     * @param string $user Username to get ingest/incoming/* folder listing for.
+     *
+     * @throws HttpClientErrorException Exception thrown when response code is 4xx negotiating with Ingest server REST API.
+     * @throws HttpServerErrorException Exception thrown when response code is 5xx negotiating with Ingest server REST API.
+     *
+     * @return array
+     */
+    public function getUsersIngestFoldersInIncomingDir(string $username)
+    {
+        $client = new Client();
+        $metadata = array();
+        $url = $this->url . '/' . $username;
+        try {
+            $response = $client->request('GET', $url);
+        } catch (ClientException $exception) {
+            throw new HttpClientErrorException($exception->getMessage(), $exception->getCode());
+        } catch (ServerException $exception) {
+            throw new HttpServerErrorException($exception->getMessage(), $exception->getCode());
+        }
+        $data = json_decode($response->getBody()->getContents(), true);
+        return $data;
+    }
+}

--- a/src/Util/IngestUtil.php
+++ b/src/Util/IngestUtil.php
@@ -25,10 +25,12 @@ class IngestUtil
     /**
      * Constructor.
      *
+     * @param string $ingestApiUrl The API URL.
      */
-    public function __construct()
-    {
-        $this->url = 'http://griidc-ingest.tamucc.edu:3000/getFolders';
+    public function __construct(
+        string $ingestApiUrl
+    ) {
+        $this->url = $ingestApiUrl;
     }
 
     /**


### PR DESCRIPTION
can test against griidc-ingest on dev/test, let me know if the node instance needs to be turned on, but I'll leave it on for now.