### PR TITLE
Remove PDF link.

### DIFF
--- a/templates/DatasetMonitoring/projects.html.twig
+++ b/templates/DatasetMonitoring/projects.html.twig
@@ -3,11 +3,6 @@
     {% if instName | default %}
         <span class="header-inst-name">({{instName}})</span>
     {% endif %}
-    {% if not pdf | default %}
-        <span class="awesome-icon awesome-icon-pdf" data-url="/html2pdf?url={{ url(app.request.get('_route'), {'id': id, 'renderer': 'html2pdf'}) }}&format=Letter&orientation=landscape&margin=1cm&download=true&filename={{pdfFilename}}">
-            <i class="fas fa-file-pdf"  style="color: red"></i>
-        </span>
-    {% endif %}
 </div>
 {% for ResearchGroup in researchGroups %}
 <div class="project" project="{{ResearchGroup.id}}">


### PR DESCRIPTION
Per discussion earlier, we're leaving the actual pdf-formatted view in place for possible future use, so this just removes the link, which is now broken anyway.