### PR TITLE
Feature/pelagos 4656 update doctine config removing db ver

### DIFF
--- a/.env
+++ b/.env
@@ -26,7 +26,7 @@ APP_SECRET=7fd781d3c8b25811ddd82260d88cc496
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
 # DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7"
-DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
+DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=14&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 ###> symfony/swiftmailer-bundle ###
 # For Gmail as a transport, use: "gmail://username:password@localhost"

--- a/bin/loaddump
+++ b/bin/loaddump
@@ -59,6 +59,7 @@ dbportname=${database_url_parts[3]}
 IFS='/' read -ra partname_array <<< "$dbportname"
 dbport=${partname_array[0]} # unused
 parameters__database_name=${partname_array[1]}
+parameters__database_name=`echo $parameters__database_name | sed s/\?.*$//`
 
 echo "WARNING!!!: This will destroy all data in the $parameters__database_name database on $parameters__database_host!"
 read -r -p "Are you sure you want to do this? [y/N] " response

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -9,9 +9,6 @@ doctrine:
                 class: App\DoctrineExtensions\DBAL\Types\CITextType
                 commented: false
 
-        # IMPORTANT: You MUST configure your server version,
-        # either here or in the DATABASE_URL env var (see .env file)
-        server_version: '9.6'
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -9,6 +9,9 @@ doctrine:
                 class: App\DoctrineExtensions\DBAL\Types\CITextType
                 commented: false
 
+        # IMPORTANT: You MUST configure your server version,
+        # either here or in the DATABASE_URL env var (see .env file)
+        # server_version: '14'
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware


### PR DESCRIPTION
This was an oversight from before when we updated the .env for the new DB configuration. We should have removed it from the doctrine.yaml config at that time. It still worked, but wasn't ideal.