### PR TITLE
Required for new Composer version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,9 @@
         "sort-packages": true,
         "platform": {
             "php": "7.3.0"
+        },
+        "allow-plugins": {
+            "symfony/flex": true
         }
     },
     "autoload": {


### PR DESCRIPTION
We were on 2.0.14. Going to the current 2.3.5 requires this change to composer.json.