### PR TITLE
Feature/pelagos 4962 log additional field

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -171,6 +171,10 @@ services:
         bind:
             FOS\ElasticaBundle\Persister\ObjectPersister $objectPersister: "@fos_elastica.object_persister.pelagos"
 
+    App\Controller\UI\SearchPageController:
+        bind:
+            string $customTemplate: '%env(CUSTOM_BASE_TEMPLATE)%'
+
     App\Util\MailerLoggerUtil:
         tags:
             - { name: "swiftmailer.default.plugin" }

--- a/src/Controller/UI/SearchPageController.php
+++ b/src/Controller/UI/SearchPageController.php
@@ -39,9 +39,14 @@ class SearchPageController extends AbstractController
     {
         $this->logActionItemEventDispatcher = $logActionItemEventDispatcher;
         if (empty($customTemplate)) {
+            // If custom template is not set, subSite is 'GRIIDC'.
             $this->subSite = 'GRIIDC';
+        } elseif ($customTemplate == 'nas-grp-base.html.twig') {
+            $this->subSite = 'GRP';
+        } elseif ($customTemplate == 'hri-base.html.twig') {
+            $this->subSite = 'HRI';
         } else {
-            $this->subSite = $customTemplate;
+            $this->subSite = 'UNKNOWN';
         }
     }
 

--- a/src/Controller/UI/SearchPageController.php
+++ b/src/Controller/UI/SearchPageController.php
@@ -24,13 +24,25 @@ class SearchPageController extends AbstractController
     protected $logActionItemEventDispatcher;
 
     /**
+     * Subsite name, based on custom template.
+     *
+     * @var string
+     */
+    protected $subSite;
+
+    /**
      * Constructor for this Controller, to set up default services.
      *
      * @param LogActionItemEventDispatcher $logActionItemEventDispatcher The log action item event dispatcher.
      */
-    public function __construct(LogActionItemEventDispatcher $logActionItemEventDispatcher)
+    public function __construct(LogActionItemEventDispatcher $logActionItemEventDispatcher, ?string $customTemplate)
     {
         $this->logActionItemEventDispatcher = $logActionItemEventDispatcher;
+        if (empty($customTemplate)) {
+            $this->subSite = 'GRIIDC';
+        } else {
+            $this->subSite = $customTemplate;
+        }
     }
 
     /**
@@ -176,7 +188,8 @@ class SearchPageController extends AbstractController
                     'clientInfo' => $clientInfo,
                     'searchQueryParams' => $searchQueryParams,
                     'numResults' => $numOfResults,
-                    'elasticScoreFirstResult' => $elasticScoreFirstResult
+                    'elasticScoreFirstResult' => $elasticScoreFirstResult,
+                    'site' => $this->subSite
                 )
             ),
             'search_terms_log'

--- a/src/Controller/UI/SearchPageController.php
+++ b/src/Controller/UI/SearchPageController.php
@@ -35,15 +35,15 @@ class SearchPageController extends AbstractController
      *
      * @param LogActionItemEventDispatcher $logActionItemEventDispatcher The log action item event dispatcher.
      */
-    public function __construct(LogActionItemEventDispatcher $logActionItemEventDispatcher, ?string $customTemplate)
+    public function __construct(LogActionItemEventDispatcher $logActionItemEventDispatcher, string $customTemplate)
     {
         $this->logActionItemEventDispatcher = $logActionItemEventDispatcher;
         if (empty($customTemplate)) {
             // If custom template is not set, subSite is 'GRIIDC'.
             $this->subSite = 'GRIIDC';
-        } elseif ($customTemplate == 'nas-grp-base.html.twig') {
+        } elseif ($customTemplate === 'nas-grp-base.html.twig') {
             $this->subSite = 'GRP';
-        } elseif ($customTemplate == 'hri-base.html.twig') {
+        } elseif ($customTemplate === 'hri-base.html.twig') {
             $this->subSite = 'HRI';
         } else {
             $this->subSite = 'UNKNOWN';

--- a/src/Controller/UI/SearchPageController.php
+++ b/src/Controller/UI/SearchPageController.php
@@ -189,7 +189,7 @@ class SearchPageController extends AbstractController
                     'searchQueryParams' => $searchQueryParams,
                     'numResults' => $numOfResults,
                     'elasticScoreFirstResult' => $elasticScoreFirstResult,
-                    'site' => $this->subSite
+                    'subSite' => $this->subSite
                 )
             ),
             'search_terms_log'


### PR DESCRIPTION
I'm using the custom template names to detect subsite, and shortening per the ticket. I don't know if we should we consider a friendly name .env var instead, or if this is alright as is.