### PR TITLE
Simplify display of difs in dataland.

### DIFF
--- a/templates/Dataland/v2/index.html.twig
+++ b/templates/Dataland/v2/index.html.twig
@@ -25,7 +25,7 @@
                         {% include 'Dataland/v2/status-badge.html.twig' %}
                         <h2> {{ dataset.title }} </h2>
                     </div>
-                    {% if dataset.dif.status == constant("App\\Entity\\DIF::STATUS_APPROVED") %}
+                    {% if dataset.datasetsubmission|default and dataset.datasetsubmission.status != constant("App\\Entity\\DatasetSubmission::STATUS_UNSUBMITTED") %}
                         <div class="d-flex justify-content-between py-2">
                             <div>
                                 <div>
@@ -46,10 +46,42 @@
                                 </div>
                             </div>
                         </div>
+                    {% elseif dataset.dif.status == constant("App\\Entity\\DIF::STATUS_APPROVED") %}
+                        <div class="d-flex justify-content-between py-2">
+                            <div>
+                                <div>
+                                    &nbsp;
+                                </div>
+                                <div>
+                                    <strong>Identified On:</strong> {{ dataset.dif.approveddate|date('M d Y H:i T', 'UTC') }}
+                                </div>
+                            </div>
+                            <div>
+                                <div>
+                                    <div>
+                                        &nbsp;
+                                    </div>
+                                    <div>
+                                        <strong>UDI:</strong> {{ dataset.udi }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     {% else %}
                         <div class="d-flex justify-content-between py-2">
                             <div>
                                 <div>
+                                    &nbsp;
+                                </div>
+                                <div>
+                                    &nbsp;
+                                </div>
+                            </div>
+                            <div>
+                                <div>
+                                    <div>
+                                        &nbsp;
+                                    </div>
                                     <div>
                                         <strong>UDI:</strong> {{ dataset.udi }}
                                     </div>

--- a/templates/Dataland/v2/index.html.twig
+++ b/templates/Dataland/v2/index.html.twig
@@ -25,42 +25,37 @@
                         {% include 'Dataland/v2/status-badge.html.twig' %}
                         <h2> {{ dataset.title }} </h2>
                     </div>
-                    {% if dataset.availabilityStatus == constant("App\\Entity\\DatasetSubmission::AVAILABILITY_STATUS_NOT_AVAILABLE") %}
-                    <div class="d-flex justify-content-between py-2">
-                        <div>
-                            <div>
-                                <strong>Identified On:</strong> {{ dataset.dif.approvedDate|date('M d Y H:i T', 'UTC') }}
-                            </div>
-                        </div>
-                        <div>
+                    {% if dataset.availabilityStatus != constant("App\\Entity\\DatasetSubmission::AVAILABILITY_STATUS_NOT_AVAILABLE") %}
+                        <div class="d-flex justify-content-between py-2">
                             <div>
                                 <div>
-                                    <strong>UDI:</strong> {{ dataset.udi }}
+                                    <strong>Authors:</strong> {{ dataset.datasetSubmission.authors|default }}
+                                </div>
+                                <div>
+                                    <strong>Published On:</strong> {{ dataset.acceptedDate|date('M d Y H:i T', 'UTC') }}
+                                </div>
+                            </div>
+                            <div>
+                                <div>
+                                    <div>
+                                        <strong>DOI:</strong> {{ dataset.doi.doi|default }}
+                                    </div>
+                                    <div>
+                                        <strong>UDI:</strong> {{ dataset.udi }}
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
                     {% else %}
-                    <div class="d-flex justify-content-between py-2">
-                        <div>
-                            <div>
-                                <strong>Authors:</strong> {{ dataset.datasetSubmission.authors|default }}
-                            </div>
-                            <div>
-                                <strong>Published On:</strong> {{ dataset.acceptedDate|date('M d Y H:i T', 'UTC') }}
-                            </div>
-                        </div>
-                        <div>
+                        <div class="d-flex justify-content-between py-2">
                             <div>
                                 <div>
-                                    <strong>DOI:</strong> {{ dataset.doi.doi|default }}
-                                </div>
-                                <div>
-                                    <strong>UDI:</strong> {{ dataset.udi }}
+                                    <div>
+                                        <strong>UDI:</strong> {{ dataset.udi }}
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
                     {% endif %}
                     <hr>
                 </div>

--- a/templates/Dataland/v2/index.html.twig
+++ b/templates/Dataland/v2/index.html.twig
@@ -25,7 +25,7 @@
                         {% include 'Dataland/v2/status-badge.html.twig' %}
                         <h2> {{ dataset.title }} </h2>
                     </div>
-                    {% if dataset.datasetsubmission|default and dataset.datasetsubmission.status != constant("App\\Entity\\DatasetSubmission::STATUS_UNSUBMITTED") %}
+                    {% if dataset.datasetsubmissionstatus != constant("App\\Entity\\DatasetSubmission::STATUS_UNSUBMITTED") %}
                         <div class="d-flex justify-content-between py-2">
                             <div>
                                 <div>
@@ -40,55 +40,33 @@
                                     <div>
                                         <strong>DOI:</strong> {{ dataset.doi.doi|default }}
                                     </div>
-                                    <div>
-                                        <strong>UDI:</strong> {{ dataset.udi }}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                     {% elseif dataset.dif.status == constant("App\\Entity\\DIF::STATUS_APPROVED") %}
                         <div class="d-flex justify-content-between py-2">
                             <div>
-                                <div>
-                                    &nbsp;
-                                </div>
+                                <div></div>
                                 <div>
                                     <strong>Identified On:</strong> {{ dataset.dif.approveddate|date('M d Y H:i T', 'UTC') }}
                                 </div>
                             </div>
                             <div>
                                 <div>
-                                    <div>
-                                        &nbsp;
-                                    </div>
-                                    <div>
-                                        <strong>UDI:</strong> {{ dataset.udi }}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                                    <div></div>
                     {% else %}
                         <div class="d-flex justify-content-between py-2">
                             <div>
-                                <div>
-                                    &nbsp;
-                                </div>
-                                <div>
-                                    &nbsp;
-                                </div>
+                                <div></div>
+                                <div></div>
                             </div>
                             <div>
                                 <div>
-                                    <div>
-                                        &nbsp;
-                                    </div>
+                                    <div></div>
+                    {% endif %}
                                     <div>
                                         <strong>UDI:</strong> {{ dataset.udi }}
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    {% endif %}
                     <hr>
                 </div>
                 <div class="sidebar w-25 float-right px-3">

--- a/templates/Dataland/v2/index.html.twig
+++ b/templates/Dataland/v2/index.html.twig
@@ -25,7 +25,7 @@
                         {% include 'Dataland/v2/status-badge.html.twig' %}
                         <h2> {{ dataset.title }} </h2>
                     </div>
-                    {% if dataset.availabilityStatus != constant("App\\Entity\\DatasetSubmission::AVAILABILITY_STATUS_NOT_AVAILABLE") %}
+                    {% if dataset.dif.status == constant("App\\Entity\\DIF::STATUS_APPROVED") %}
                         <div class="d-flex justify-content-between py-2">
                             <div>
                                 <div>

--- a/templates/Dataland/v2/index.html.twig
+++ b/templates/Dataland/v2/index.html.twig
@@ -25,13 +25,29 @@
                         {% include 'Dataland/v2/status-badge.html.twig' %}
                         <h2> {{ dataset.title }} </h2>
                     </div>
+                    {% if dataset.availabilityStatus == constant("App\\Entity\\DatasetSubmission::AVAILABILITY_STATUS_NOT_AVAILABLE") %}
+                    <div class="d-flex justify-content-between py-2">
+                        <div>
+                            <div>
+                                <strong>Identified On:</strong> {{ dataset.dif.approvedDate|date('M d Y H:i T', 'UTC') }}
+                            </div>
+                        </div>
+                        <div>
+                            <div>
+                                <div>
+                                    <strong>UDI:</strong> {{ dataset.udi }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {% else %}
                     <div class="d-flex justify-content-between py-2">
                         <div>
                             <div>
                                 <strong>Authors:</strong> {{ dataset.datasetSubmission.authors|default }}
                             </div>
                             <div>
-                                <strong>Published on </strong> {{ dataset.acceptedDate|date('M d Y H:i T', 'UTC') }}
+                                <strong>Published On:</strong> {{ dataset.acceptedDate|date('M d Y H:i T', 'UTC') }}
                             </div>
                         </div>
                         <div>
@@ -45,6 +61,7 @@
                             </div>
                         </div>
                     </div>
+                    {% endif %}
                     <hr>
                 </div>
                 <div class="sidebar w-25 float-right px-3">


### PR DESCRIPTION
I'm not too keen on using (only) dataset.availabilityStatus == constant("App\\Entity\\DatasetSubmission::AVAILABILITY_STATUS_NOT_AVAILABLE" as basis for identifying DIF status datasets, but we're already doing this for the badges. We should probably discuss. Maybe it's alright.