### PR TITLE
feature/pelagos-5060-fix-supervisord-paths

### DIFF
--- a/config/supervisor/messenger-worker.ini
+++ b/config/supervisor/messenger-worker.ini
@@ -2,6 +2,7 @@
 programs=normal-consume,low-consume,doi-consume
 
 [program:normal-consume]
+directory=/opt/pelagos
 command=php bin/console messenger:consume async_normal --time-limit=3600
 user=pelagos
 numprocs=10
@@ -10,6 +11,7 @@ autorestart=true
 process_name=%(program_name)s_%(process_num)02d
 
 [program:low-consume]
+directory=/opt/pelagos
 command=php bin/console messenger:consume async_low --time-limit=3600
 user=pelagos
 numprocs=5
@@ -18,6 +20,7 @@ autorestart=true
 process_name=%(program_name)s_%(process_num)02d
 
 [program:doi-consume]
+directory=/opt/pelagos
 command=php bin/console messenger:consume async_doi --time-limit=3600 --limit=10
 user=pelagos
 numprocs=1

--- a/config/supervisor/supervisord.conf
+++ b/config/supervisor/supervisord.conf
@@ -1,10 +1,10 @@
 [unix_http_server]
-file=var/supervisor/supervisor.sock
+file=/opt/pelagos/var/supervisor/supervisor.sock
 chmod=0700
 
 [supervisord]
-logfile=var/supervisor/supervisord.log
-pidfile=var/supervisor/supervisor.pid
+logfile=/opt/pelagos/var/supervisor/supervisord.log
+pidfile=/opt/pelagos/var/supervisor/supervisor.pid
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface


### PR DESCRIPTION
This is needed if pelagos is intalled at a location other than the pelagos user's homedir. It was as early mistake making the pelagos homedir /opt/pelagos. On new server instances, it is /home/pelagos and the installation still happens at /opt/pelagos as normal. We just shouldn't rely on ~/ referring to the install location anymore. This keeps certain non-pelagos homedir related stuff out of our basedir.