### PR TITLE
Order Funder by name in repo.

### DIFF
--- a/src/Repository/FunderRepository.php
+++ b/src/Repository/FunderRepository.php
@@ -54,7 +54,8 @@ class FunderRepository extends ServiceEntityRepository
         $qb = $this->createQueryBuilder('f')
             ->select('f.id, f.name')
             ->where('LOWER(f.name) like LOWER(:queryString)')
-            ->setParameter('queryString', "%$userQueryString%");
+            ->setParameter('queryString', "%$userQueryString%")
+            ->orderBy('f.name');
 
         return $qb->getQuery()->getArrayResult();
     }


### PR DESCRIPTION
This also fixes the order everywhere else (review, submission).  When we switch to shortname, we'll have to decide whether order should be based on name or short name, but for now it's name.