### PR TITLE
Feature/pelagos 5167 add sort to initial paramaterless search results on current search tool

### DIFF
--- a/config/packages/fos_elastica.yaml
+++ b/config/packages/fos_elastica.yaml
@@ -140,7 +140,6 @@ fos_elastica:
                     type: 'boolean'
                 acceptedDate:
                     type: 'date'
-                    property_path: false
                     format: 'yyyy-MM-dd'
                 publications:
                     type: 'nested'

--- a/config/packages/fos_elastica.yaml
+++ b/config/packages/fos_elastica.yaml
@@ -138,9 +138,10 @@ fos_elastica:
                 coldStorage:
                     property_path: false
                     type: 'boolean'
-                accepted:
-                    type: 'boolean'
+                acceptedDate:
+                    type: 'date'
                     property_path: false
+                    format: 'yyyy-MM-dd'
                 publications:
                     type: 'nested'
                     properties:

--- a/config/packages/fos_elastica.yaml
+++ b/config/packages/fos_elastica.yaml
@@ -138,6 +138,9 @@ fos_elastica:
                 coldStorage:
                     property_path: false
                     type: 'boolean'
+                accepted:
+                    type: 'boolean'
+                    property_path: false
                 publications:
                     type: 'nested'
                     properties:
@@ -155,7 +158,7 @@ fos_elastica:
                 funders:
                     type: 'nested'
                     properties:
-                        id: 
+                        id:
                             type: 'keyword'
         info_products:
             client: default

--- a/src/Event/DatasetIndexSubscriber.php
+++ b/src/Event/DatasetIndexSubscriber.php
@@ -112,6 +112,12 @@ class DatasetIndexSubscriber implements EventSubscriberInterface
                 $document->set('collectionStartDate', $collectionStartDate->format('Y-m-d H:i:s'));
                 $document->set('collectionEndDate', $collectionEndDate->format('Y-m-d H:i:s'));
             }
+            // set Accepted bool in index.
+            if ($dataset->getDatasetStatus() === 'Accepted') {
+                $document->set('accepted', true);
+            } else {
+                $document->set('accepted', false);
+            }
         } elseif ($dataset->hasDif()) {
             if ($dataset->getDif()->getModificationTimeStamp() instanceof \DateTime) {
                 $document->set('updatedDateTime', $dataset->getDif()->getModificationTimeStamp()->format('Ymd\THis\Z'));

--- a/src/Event/DatasetIndexSubscriber.php
+++ b/src/Event/DatasetIndexSubscriber.php
@@ -112,12 +112,6 @@ class DatasetIndexSubscriber implements EventSubscriberInterface
                 $document->set('collectionStartDate', $collectionStartDate->format('Y-m-d H:i:s'));
                 $document->set('collectionEndDate', $collectionEndDate->format('Y-m-d H:i:s'));
             }
-            // set Accepted bool in index.
-            if ($dataset->getDatasetStatus() === 'Accepted') {
-                $document->set('accepted', true);
-            } else {
-                $document->set('accepted', false);
-            }
         } elseif ($dataset->hasDif()) {
             if ($dataset->getDif()->getModificationTimeStamp() instanceof \DateTime) {
                 $document->set('updatedDateTime', $dataset->getDif()->getModificationTimeStamp()->format('Ymd\THis\Z'));

--- a/src/Util/Search.php
+++ b/src/Util/Search.php
@@ -11,9 +11,9 @@ use App\Entity\FundingCycle;
 use App\Entity\ResearchGroup;
 use RecursiveIteratorIterator;
 use App\Entity\DatasetSubmission;
+use Elastica\Query\SimpleQueryString;
 use Doctrine\ORM\EntityManagerInterface;
 use FOS\ElasticaBundle\Finder\TransformedFinder;
-use Elastica\Query\SimpleQueryString;
 
 /**
  * Util class for FOS Elastic Search.
@@ -195,7 +195,9 @@ class Search
 
         // Add sort order
         if ($defaultSearch) {
-            $mainQuery->addSort([self::ELASTIC_INDEX_MAPPING_SORTING_DATE => ['order' => $sortOrder]]);
+            // Show accepted datasets first. The 'accepted' is a boolean set where datasetSubmission
+            // status == 'Accepted' by the DatasetIndexSubscriber.
+            $mainQuery->addSort(['accepted' => ['order' => 'desc'], self::ELASTIC_INDEX_MAPPING_SORTING_DATE => ['order' => 'desc']]);
         } elseif ('default' !== $sortOrder) {
             $mainQuery->addSort([self::ELASTIC_INDEX_MAPPING_SORTING_DATE => ['order' => $sortOrder]]);
         }

--- a/src/Util/Search.php
+++ b/src/Util/Search.php
@@ -137,7 +137,7 @@ class Search
         $sortOrder = $requestTerms['sortOrder'];
         $collectionDateRange = [];
 
-        // Is this a default no-parameters search?
+        // Is this the inital datasets display (no user-added parameters) search?
         if (
             empty($requestTerms['query'])
             && empty($requestTerms['field'])
@@ -150,9 +150,9 @@ class Search
             && empty($requestTerms['options']['projectDirectorId'])
             && empty($requestTerms['options']['funderId'])
         ) {
-            $defaultSearch = true;
+            $isInitialSearch = true;
         } else {
-            $defaultSearch = false;
+            $isInitialSearch = false;
         }
 
         if ($requestTerms['collectionStartDate'] or $requestTerms['collectionEndDate']) {
@@ -194,10 +194,9 @@ class Search
         $mainQuery->setQuery($subMainQuery);
 
         // Add sort order
-        if ($defaultSearch) {
-            // Show accepted datasets first. The 'accepted' is a boolean set where datasetSubmission
-            // status == 'Accepted' by the DatasetIndexSubscriber.
-            $mainQuery->addSort(['accepted' => ['order' => 'desc'], self::ELASTIC_INDEX_MAPPING_SORTING_DATE => ['order' => 'desc']]);
+        if ($isInitialSearch) {
+            // Show accepted datasets first.
+            $mainQuery->addSort(['acceptedDate' => ['order' => 'desc']]);
         } elseif ('default' !== $sortOrder) {
             $mainQuery->addSort([self::ELASTIC_INDEX_MAPPING_SORTING_DATE => ['order' => $sortOrder]]);
         }


### PR DESCRIPTION
The acceptance criteria cite acceptedDate, which is what the sortingDateForDisplay already gets for cases of accepted submission. In other cases it falls through to the submissiontimestamp, but those are already  grouped below all the accepted datasets per the 'accepted' bool I set up in the index, populated by datasetIndexSubscriber.

If there's a cleaner approach, please let me know.