### PR TITLE
feature/PELAGOS-5191-add-anzsrc-keywords-to-metadata

### DIFF
--- a/templates/MetadataGenerator/ANZSRC_Keywords.xml.twig
+++ b/templates/MetadataGenerator/ANZSRC_Keywords.xml.twig
@@ -1,7 +1,4 @@
 <gmd:MD_Keywords>
-    {% if keywords is empty %}
-    <gmd:keyword gco:nilReason="inapplicable" />
-    {% endif %}
     {% for keyword in keywords %}
     <gmd:keyword>
         <gmx:Anchor xlink:role="uri" xlink:href="{{keyword.referenceUri}}" xlink:show="new">{{keyword.label}}</gmx:Anchor>
@@ -21,7 +18,7 @@
                         <gco:Date>2020</gco:Date>
                     </gmd:date>
                     <gmd:dateType>
-                        <gmd:CI_DateTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                        <gmd:CI_DateTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">ANZSRC 2020</gmd:CI_DateTypeCode>
                     </gmd:dateType>
                 </gmd:CI_Date>
             </gmd:date>

--- a/templates/MetadataGenerator/ANZSRC_Keywords.xml.twig
+++ b/templates/MetadataGenerator/ANZSRC_Keywords.xml.twig
@@ -1,0 +1,34 @@
+<gmd:MD_Keywords>
+    {% if keywords is empty %}
+    <gmd:keyword gco:nilReason="inapplicable" />
+    {% endif %}
+    {% for keyword in keywords %}
+    <gmd:keyword>
+        <gmx:Anchor xlink:role="uri" xlink:href="{{keyword.referenceUri}}" xlink:show="new">{{keyword.label}}</gmx:Anchor>
+    </gmd:keyword>
+    {% endfor %}
+    <gmd:type>
+        <gmd:MD_KeywordTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="discipline">discipline</gmd:MD_KeywordTypeCode>
+    </gmd:type>
+    <gmd:thesaurusName>
+        <gmd:CI_Citation>
+            <gmd:title>
+                <gco:CharacterString>ANZSRC Fields of Research</gco:CharacterString>
+            </gmd:title>
+            <gmd:date>
+                <gmd:CI_Date>
+                    <gmd:date>
+                        <gco:Date>2020</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                </gmd:CI_Date>
+            </gmd:date>
+            <gmd:edition gco:nilReason="unknown"/>
+            <gmd:otherCitationDetails>
+                <gco:CharacterString>Australian Bureau of Statistics (2020): Australian and New Zealand Standard Research Classification (ANZSRC). https://www.abs.gov.au</gco:CharacterString>
+            </gmd:otherCitationDetails>
+        </gmd:CI_Citation>
+    </gmd:thesaurusName>
+</gmd:MD_Keywords>

--- a/templates/MetadataGenerator/MD_DataIdentification.xml.twig
+++ b/templates/MetadataGenerator/MD_DataIdentification.xml.twig
@@ -68,7 +68,7 @@
     <gmd:descriptiveKeywords>
         {% set anzsrc_keywords = [] %}
         {% for keyword in dataset.datasetSubmission.keywords %}
-            {% if keyword.type.value == 'anzsrc' %}
+            {% if keyword.type == constant('\\App\\Enum\\KeywordType::TYPE_ANZSRC') %}
                 {% set anzsrc_keywords = anzsrc_keywords|merge([keyword]) %}
             {% endif %}
         {% endfor %}

--- a/templates/MetadataGenerator/MD_DataIdentification.xml.twig
+++ b/templates/MetadataGenerator/MD_DataIdentification.xml.twig
@@ -65,6 +65,21 @@
             }
         %}
     </gmd:descriptiveKeywords>
+    <gmd:descriptiveKeywords>
+        {% set anzsrc_keywords = [] %}
+        {% for keyword in dataset.datasetSubmission.keywords %}
+            {% if keyword.type.value == 'anzsrc' %}
+                {% set anzsrc_keywords = anzsrc_keywords|merge([keyword]) %}
+            {% endif %}
+        {% endfor %}
+        {% if anzsrc_keywords %}
+            {% include "MetadataGenerator/ANZSRC_Keywords.xml.twig" with
+                {
+                    "keywords" : anzsrc_keywords,
+                }
+            %}
+        {% endif %}
+    </gmd:descriptiveKeywords>
     <gmd:resourceConstraints xlink:title="Cite As">
         <gmd:MD_Constraints>
             <gmd:useLimitation>

--- a/templates/MetadataGenerator/MD_DataIdentification.xml.twig
+++ b/templates/MetadataGenerator/MD_DataIdentification.xml.twig
@@ -57,6 +57,7 @@
             }
         %}
     </gmd:descriptiveKeywords>
+
     <gmd:descriptiveKeywords>
         {% include "MetadataGenerator/MD_Keywords.xml.twig" with
             {
@@ -65,7 +66,7 @@
             }
         %}
     </gmd:descriptiveKeywords>
-    <gmd:descriptiveKeywords>
+
         {% set anzsrc_keywords = [] %}
         {% for keyword in dataset.datasetSubmission.keywords %}
             {% if keyword.type == constant('\\App\\Enum\\KeywordType::TYPE_ANZSRC') %}
@@ -73,13 +74,14 @@
             {% endif %}
         {% endfor %}
         {% if anzsrc_keywords %}
+            <gmd:descriptiveKeywords>
             {% include "MetadataGenerator/ANZSRC_Keywords.xml.twig" with
                 {
                     "keywords" : anzsrc_keywords,
                 }
             %}
+            </gmd:descriptiveKeywords>
         {% endif %}
-    </gmd:descriptiveKeywords>
     <gmd:resourceConstraints xlink:title="Cite As">
         <gmd:MD_Constraints>
             <gmd:useLimitation>


### PR DESCRIPTION
Needs PELAGOS-5172 merged into the epic first so we have metadata to generate from a submission with anzsrc keywords.