### PR TITLE
Feature/pelagos 5191 add anzsrc keywords to metadata generator

### DIFF
--- a/templates/MetadataGenerator/ANZSRC_Keywords.xml.twig
+++ b/templates/MetadataGenerator/ANZSRC_Keywords.xml.twig
@@ -18,7 +18,7 @@
                         <gco:Date>2020</gco:Date>
                     </gmd:date>
                     <gmd:dateType>
-                        <gmd:CI_DateTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">ANZSRC 2020</gmd:CI_DateTypeCode>
+                        <gmd:CI_DateTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
                     </gmd:dateType>
                 </gmd:CI_Date>
             </gmd:date>


### PR DESCRIPTION
Switched back to 'revisions' string in MD template.