### PR TITLE
Corrected filename

### DIFF
--- a/assets/js/vue/components/data-land/DownloadZipBtn.vue
+++ b/assets/js/vue/components/data-land/DownloadZipBtn.vue
@@ -68,7 +68,6 @@
                         <strong>UDI:</strong> {{ datasetInfo.dataset.udi }}<br>
                         <strong>File name:</strong> {{ datasetInfo.dataset.filename }}<br>
                         <strong>File size:</strong> {{ datasetInfo.dataset.fileSize }}<br>
-                        <strong>SHA256 Checksum:</strong> {{ datasetInfo.dataset.checksum }}<br>
                         <strong>Estimated Download Time:</strong> {{ estimatedDownloadTime }}<br>
                     </div>
                 </div>

--- a/src/Controller/DownloadController.php
+++ b/src/Controller/DownloadController.php
@@ -227,7 +227,7 @@ class DownloadController extends AbstractController
         );
 
         if ($datasetSubmission instanceof DatasetSubmission) {
-            $datasetInfo['filename'] = $datasetSubmission->getDatasetFileName();
+            $datasetInfo['filename'] = str_replace(':', '.', $dataset->getUdi()) . '.zip';
             $datasetInfo['fileSize'] = TwigExtentions::formatBytes($datasetSubmission->getDatasetFileSize(), 2);
             $datasetInfo['fileSizeRaw'] = $datasetSubmission->getDatasetFileSize();
             $datasetInfo['checksum'] = $datasetSubmission->getDatasetFileSha256Hash();


### PR DESCRIPTION
Because filename would say first filename, because zip is no longer available. Also remove SHA256 because zip is now dynamic.