### PR TITLE
Need field name in template.

### DIFF
--- a/src/Controller/UI/AccountController.php
+++ b/src/Controller/UI/AccountController.php
@@ -109,7 +109,7 @@ class AccountController extends AbstractController
         $emailAddress = $request->request->get('emailAddress');
         $reset = ($request->request->get('reset') == 'reset') ? true : false;
 
-        // Don't trust the public untrusted form to not send nulls/empties. EH doesn't like nulls.
+        // Don't allow null/empty field.
         if (empty($emailAddress)) {
             $people = [];
         } else {

--- a/src/Controller/UI/AccountController.php
+++ b/src/Controller/UI/AccountController.php
@@ -109,7 +109,12 @@ class AccountController extends AbstractController
         $emailAddress = $request->request->get('emailAddress');
         $reset = ($request->request->get('reset') == 'reset') ? true : false;
 
-        $people = $this->entityHandler->getBy(Person::class, array('emailAddress' => $emailAddress));
+        // Don't trust the public untrusted form to not send nulls/empties. EH doesn't like nulls.
+        if (empty($emailAddress)) {
+            $people = [];
+        } else {
+            $people = $this->entityHandler->getBy(Person::class, array('emailAddress' => $emailAddress));
+        }
 
         if (count($people) === 0) {
             return $this->render('Account/EmailNotFound.html.twig');

--- a/src/Controller/UI/AccountController.php
+++ b/src/Controller/UI/AccountController.php
@@ -2,24 +2,24 @@
 
 namespace App\Controller\UI;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Mime\Address;
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\HttpFoundation\Response;
 use App\Entity\Account;
 use App\Entity\Entity;
 use App\Entity\Password;
 use App\Entity\Person;
 use App\Entity\PersonToken;
-use App\Exception\PasswordException;
 use App\Event\EntityEventDispatcher;
+use App\Exception\PasswordException;
 use App\Handler\EntityHandler;
 use App\Repository\PersonRepository;
 use App\Util\Factory\UserIdFactory;
 use App\Util\Ldap\Ldap;
 use App\Util\MailSender;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * The account controller.

--- a/templates/Account/Account.html.twig
+++ b/templates/Account/Account.html.twig
@@ -19,7 +19,7 @@
                     <span>To request a GRIIDC account, please provide your email address associated with your funding agreement.</span>
                         <form id="accountForm" method="post" action="{{ path('pelagos_app_ui_account_sendverificationemail') }}">
                             <label for="emailAddress">Email Address:</label>
-                            <input type="email" required class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+                            <input type="email" name="emailAddress" required class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
                             <label style="display:inline;" for="emailAddress" class="error"></label>
                             <div class="py-2">
                                 <button type="submit" class="flex w-small justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Submit</button>


### PR DESCRIPTION
Server crashes without this! (causes nasty db-loop, which we should probably investigate deeper as sending this form in with a null from an un-authenticated field results in an easy-to-violate vulnerability resulting in a crashed instance.) 