### PR TITLE
Feature/pelagos 5350 make column width for udi and doi narrower

### DIFF
--- a/templates/DatasetMonitoring/index.html.twig
+++ b/templates/DatasetMonitoring/index.html.twig
@@ -22,7 +22,7 @@
       }
 
       .dsmonitoringcols {
-        white-space: nowrap!important;
+        white-space: nowrap;
       }
     </style>
 {% endblock stylesheets  %}

--- a/templates/DatasetMonitoring/index.html.twig
+++ b/templates/DatasetMonitoring/index.html.twig
@@ -20,6 +20,10 @@
       input[type='text'].dx-texteditor-input:focus {
         box-shadow: none!important;
       }
+
+      .dsmonitoringcols {
+        white-space: nowrap!important;
+      }
     </style>
 {% endblock stylesheets  %}
 

--- a/templates/DatasetMonitoring/index.html.twig
+++ b/templates/DatasetMonitoring/index.html.twig
@@ -24,6 +24,13 @@
       .dsmonitoringcols {
         white-space: nowrap;
       }
+
+      .dx-treelist [tabindex]:not([tabindex="-1"]):focus-visible:focus-visible {
+        outline: none;
+      }
+      .dx-datagrid [tabindex]:not([tabindex="-1"]):focus-visible:focus-visible {
+        outline: none;
+      }
     </style>
 {% endblock stylesheets  %}
 

--- a/templates/DatasetMonitoring/v2/researchGroups.html.twig
+++ b/templates/DatasetMonitoring/v2/researchGroups.html.twig
@@ -28,11 +28,11 @@
         columns: [{
             dataField: 'udi',
             caption: 'UDI',
-            columnAutoWidth: 'true',
+            width: 160,
             },{
                 dataField: 'doi',
                 caption: 'DOI',
-                columnAutoWidth: 'true',
+                width: 222,
                 cssClass: 'dsmonitoringcols',
             },{
                 dataField: 'title',

--- a/templates/DatasetMonitoring/v2/researchGroups.html.twig
+++ b/templates/DatasetMonitoring/v2/researchGroups.html.twig
@@ -28,11 +28,11 @@
         columns: [{
             dataField: 'udi',
             caption: 'UDI',
-            width: '8.75rem',
+            width: '10.25rem',
             },{
                 dataField: 'doi',
                 caption: 'DOI',
-                width: '9.5rem',
+                width: '10.25rem',
             },{
                 dataField: 'title',
                 caption: 'Title',

--- a/templates/DatasetMonitoring/v2/researchGroups.html.twig
+++ b/templates/DatasetMonitoring/v2/researchGroups.html.twig
@@ -28,11 +28,11 @@
         columns: [{
             dataField: 'udi',
             caption: 'UDI',
-            width: '10rem',
+            width: '8.75rem',
             },{
                 dataField: 'doi',
                 caption: 'DOI',
-                width: '12rem',
+                width: '9.5rem',
             },{
                 dataField: 'title',
                 caption: 'Title',

--- a/templates/DatasetMonitoring/v2/researchGroups.html.twig
+++ b/templates/DatasetMonitoring/v2/researchGroups.html.twig
@@ -28,11 +28,12 @@
         columns: [{
             dataField: 'udi',
             caption: 'UDI',
-            width: '10.25rem',
+            columnAutoWidth: 'true',
             },{
                 dataField: 'doi',
                 caption: 'DOI',
-                width: '10.25rem',
+                columnAutoWidth: 'true',
+                cssClass: 'dsmonitoringcols',
             },{
                 dataField: 'title',
                 caption: 'Title',

--- a/templates/DatasetMonitoring/v2/researchGroups.html.twig
+++ b/templates/DatasetMonitoring/v2/researchGroups.html.twig
@@ -32,7 +32,7 @@
             },{
                 dataField: 'doi',
                 caption: 'DOI',
-                width: 252,
+                width: 201,
                 cssClass: 'dsmonitoringcols',
             },{
                 dataField: 'title',

--- a/templates/DatasetMonitoring/v2/researchGroups.html.twig
+++ b/templates/DatasetMonitoring/v2/researchGroups.html.twig
@@ -28,7 +28,7 @@
         columns: [{
             dataField: 'udi',
             caption: 'UDI',
-            width: 180,
+            columnAutoWidth: true,
             },{
                 dataField: 'doi',
                 caption: 'DOI',

--- a/templates/DatasetMonitoring/v2/researchGroups.html.twig
+++ b/templates/DatasetMonitoring/v2/researchGroups.html.twig
@@ -28,11 +28,11 @@
         columns: [{
             dataField: 'udi',
             caption: 'UDI',
-            width: 160,
+            width: 180,
             },{
                 dataField: 'doi',
                 caption: 'DOI',
-                width: 222,
+                width: 252,
                 cssClass: 'dsmonitoringcols',
             },{
                 dataField: 'title',


### PR DESCRIPTION
shrank slightly, if we're ok with the longer DOIs breaking, I think this could work. The new-issued DOIs all are on a single line.