### PR TITLE
Update template copyright dates.

### DIFF
--- a/templates/Default/hri-index.html.twig
+++ b/templates/Default/hri-index.html.twig
@@ -81,7 +81,7 @@
         </div>
         <footer class="py-5 bg-dark">
             <div class="container">
-                <p class="m-0 text-center text-white">Copyright &copy; HRI - GRIIDC 2022</p>
+                <p class="m-0 text-center text-white">Copyright &copy; HRI - GRIIDC 2024</p>
             </div>
         </footer>
     </div>

--- a/templates/Default/nas-grp-index.html.twig
+++ b/templates/Default/nas-grp-index.html.twig
@@ -84,7 +84,7 @@
         </div>
         <footer class="py-5 bg-dark">
             <div class="container">
-                <p class="m-0 text-center text-white">Copyright &copy; GRP - GRIIDC 2022</p>
+                <p class="m-0 text-center text-white">Copyright &copy; GRP - GRIIDC 2024</p>
             </div>
         </footer>
     </div>


### PR DESCRIPTION
I just found this, still on 2022. In the future, could we just use {{ "now"|date("Y") }} ?
