### PR TITLE
Remove no longer used env vars.

### DIFF
--- a/.env
+++ b/.env
@@ -46,17 +46,9 @@ ACCOUNT_LESS_STRICT_PASSWORD_RULES=0
 MAILER_FROM_ADDR='email@domain.null'
 MAILER_FROM_NAME='SenderName'
 MAILER_BCC_ADDR='email@domain.null'
-PELAGOS_NAME=pelagos
 ISSUE_TRACKING_BASE_URL='https://griidc.atlassian.net/browse'
 DATABASE_NAME=pelagos
 DATA_STORE_DIRECTORY=/path/to/store/directory
-DATA_DOWNLOAD_DIRECTORY=/path/to/download/directory
-DATA_STORE_OWNER=user
-DATA_STORE_GROUP=group
-DATA_DOWNLOAD_BROWSER_GROUP=browser_group
-WEB_SERVER_USER=apache
-ANONYMOUS_FTP_USER=user
-ANONYMOUS_FTP_PASS=pass
 DOWNLOAD_PATH="path/to/zip"
 INGEST_API_URL="https://ingest-server:port/api-name"
 GCMD_VERSION="16.9"
@@ -77,7 +69,6 @@ DOWNLOAD_BASE_URL=https://server-name/path/file-download
 POSIX_STARTING_UID=10000
 POSIX_GID=1001
 REQUEST_CONTEXT_BASE_URL='/pelagos-symfony'
-FILESYSTEM_TYPE='Linux'
 
 ###> DOI API Parameters ###
 DOI_API_USER_NAME="username"


### PR DESCRIPTION
Please double check, but I could not find these used anywhere anymore. Furthermore, I think there are still a couple that are made available and referenced by the yaml configs, but no longer used. These here are just the low hanging fruits I think are safe to remove.

DATABASE_NAME is still around only because it's needed in a migration, so I guess it stays unless we update the old migration to reference the new style database DSN to get the db name from.