### PR TITLE
feature/PELAGOS-5368-Create-log-action-item-viewer

### DIFF
--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Admin;
 use App\Entity\DigitalResourceTypeDescriptor;
 use App\Entity\Funder;
 use App\Entity\FundingOrganization;
+use App\Entity\LogActionItem;
 use App\Entity\ProductTypeDescriptor;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
@@ -45,6 +46,8 @@ class DashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Admin Links', 'fa fa-link');
+        yield MenuItem::section('Viewers');
+        yield MenuItem::linkToCrud('Logged Actions', 'fas fa-search', LogActionItem::class);
         yield MenuItem::section('Editors');
         yield MenuItem::linkToCrud('IP Product Descriptor', 'fas fa-list-alt', ProductTypeDescriptor::class);
         yield MenuItem::linkToCrud('IP Digital Resource Descriptor', 'fas fa-list-alt', DigitalResourceTypeDescriptor::class);

--- a/src/Controller/Admin/LogActionItemCrudController.php
+++ b/src/Controller/Admin/LogActionItemCrudController.php
@@ -3,7 +3,6 @@
 namespace App\Controller\Admin;
 
 use App\Entity\LogActionItem;
-use DateTime;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;

--- a/src/Controller/Admin/LogActionItemCrudController.php
+++ b/src/Controller/Admin/LogActionItemCrudController.php
@@ -61,5 +61,4 @@ class LogActionItemCrudController extends AbstractCrudController
             ->setDefaultSort(['creationTimeStamp' => 'DESC'])
             ->showEntityActionsInlined();
     }
-
 }

--- a/src/Controller/Admin/LogActionItemCrudController.php
+++ b/src/Controller/Admin/LogActionItemCrudController.php
@@ -45,7 +45,9 @@ class LogActionItemCrudController extends AbstractCrudController
             ->onlyOnIndex(),
             TextField::new('actionName', 'What Happened'),
             TextField::new('subjectEntityName', 'Happened To'),
+            IdField::new('subjectEntityId', 'Which One'),
             DateTimeField::new('creationTimeStamp', 'Happened When'),
+            TextField::new('payloadDetails'),
         ];
     }
 
@@ -58,7 +60,6 @@ class LogActionItemCrudController extends AbstractCrudController
     {
         return parent::configureCrud($crud)
             ->setPageTitle(Crud::PAGE_INDEX, 'Logged Actions')
-            ->setDefaultSort(['creationTimeStamp' => 'DESC'])
-            ->showEntityActionsInlined();
+            ->setDefaultSort(['creationTimeStamp' => 'DESC']);
     }
 }

--- a/src/Controller/Admin/LogActionItemCrudController.php
+++ b/src/Controller/Admin/LogActionItemCrudController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use App\Entity\LogActionItem;
+use DateTime;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+
+class LogActionItemCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return LogActionItem::class;
+    }
+
+    /**
+     * Configure the Crud actions.
+     *
+     * @param Actions $actions actions object that need to be configured
+     */
+    public function configureActions(Actions $actions): Actions
+    {
+        $actions->disable(Action::NEW);
+        $actions->disable(Action::EDIT);
+        $actions->disable(Action::DELETE);
+
+        return $actions;
+    }
+
+    /**
+     * Configure fields for EZAdmin CRUD Controller.
+     *
+     * @param string $pageName default param for parent method (not used)
+     */
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            IdField::new('id')
+            ->onlyOnIndex(),
+            TextField::new('actionName', 'What Happened'),
+            TextField::new('subjectEntityName', 'Happened To'),
+            DateTimeField::new('creationTimeStamp', 'Happened When'),
+        ];
+    }
+
+    /**
+     * CRUD configuration function.
+     *
+     * @param Crud $crud instance for crud controller to add additional configuration
+     */
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setPageTitle(Crud::PAGE_INDEX, 'Logged Actions')
+            ->setDefaultSort(['creationTimeStamp' => 'DESC'])
+            ->showEntityActionsInlined();
+    }
+
+}

--- a/src/Entity/LogActionItem.php
+++ b/src/Entity/LogActionItem.php
@@ -227,12 +227,24 @@ class LogActionItem extends Entity
         } elseif ($action === 'File Download') {
             $userType = $json['userType'];
             $userId = $json['userId'];
-            $text = "The $userType user $userId downloaded an archive.";
+            $udi = $json['udi'] ?? null;
+            $text = "The $userType user $userId downloaded a complete zip";
+            if (!empty($udi)) {
+                $text .= " of dataset $udi";
+            } else {
+                $text .= '.';
+            }
         } elseif ($action === 'Single File Download') {
             $userType = $json['userType'];
             $userId = $json['userId'];
             $filename = $json['filename'];
-            $text = "The $userType user $userId downloaded the single file $filename.";
+            $udi = $json['udi'] ?? null;
+             $text = "The $userType user $userId downloaded the single file $filename";
+            if (!empty($udi)) {
+                $text .= " from dataset $udi";
+            } else {
+                $text .= '.';
+            }
         } elseif ($action === 'Dataset Deletion') {
             $udi = $json['UDI'];
             $user = $json['userId'];

--- a/src/Entity/LogActionItem.php
+++ b/src/Entity/LogActionItem.php
@@ -196,4 +196,56 @@ class LogActionItem extends Entity
     {
         return $this->payLoad;
     }
+
+    /**
+     * Virtual function that returns a stringified payload, making sense per json type.
+     *
+     */
+    public function getPayloadDetails(): string
+    {
+        $json = $this->payLoad;
+        $action = $this->getActionName();
+
+        if ($action === 'New Search') {
+            $userType = $json['clientInfo']['userType'];
+            $userId = $json['clientInfo']['userId'];
+            $terms = $json['searchQueryParams']['inputFormTerms']['searchTerms'];
+            $subsite = $json['subSite'];
+            $text = "The $userType user $userId searched for \"$terms\" on subsite $subsite.";
+        } elseif ($action === 'Search') {
+            $terms = $json['filters']['textFilter'];
+            $geo = $json['filters']['geoFilter'];
+            $text = "Data discovery search with text \"$terms\"";
+            if (!empty($geo)) {
+                $text .= " and used a map search";
+            }
+            $text .= '.';
+        } elseif ($action === 'Mark as Remotely Hosted') {
+            $userId = $json['userId'];
+            $submissionId = $json['datasetSubmissionId'];
+            $text = "User $userId set remotely hosted on submission id $submissionId";
+        } elseif ($action === 'File Download') {
+            $userType = $json['userType'];
+            $userId = $json['userId'];
+            $text = "The $userType user $userId downloaded an archive.";
+        } elseif ($action === 'Single File Download') {
+            $userType = $json['userType'];
+            $userId = $json['userId'];
+            $filename = $json['filename'];
+            $text = "The $userType user $userId downloaded the single file $filename.";
+        } elseif ($action === 'Dataset Deletion') {
+            $udi = $json['UDI'];
+            $user = $json['userId'];
+            $text = "$user deleted dataset $udi.";
+        } elseif ($action === 'Restriction Change') {
+            $userId = $json['userId'];
+            $from = $json['previousRestriction'];
+            $to = $json['newRestriction'];
+            $text = "$userId changed dataset restriction flag from $from to $to.";
+        } else {
+            $text = 'Warning: Unknown JSON. Extend getPayloadDetails method in LogActionItemCrudController class.';
+        }
+
+        return $text;
+    }
 }

--- a/src/Entity/LogActionItem.php
+++ b/src/Entity/LogActionItem.php
@@ -199,7 +199,6 @@ class LogActionItem extends Entity
 
     /**
      * Virtual function that returns a stringified payload, making sense per json type.
-     *
      */
     public function getPayloadDetails(): string
     {

--- a/src/Entity/LogActionItem.php
+++ b/src/Entity/LogActionItem.php
@@ -207,27 +207,27 @@ class LogActionItem extends Entity
         $action = $this->getActionName();
 
         if ($action === 'New Search') {
-            $userType = $json['clientInfo']['userType'];
-            $userId = $json['clientInfo']['userId'];
-            $terms = $json['searchQueryParams']['inputFormTerms']['searchTerms'];
-            $subsite = $json['subSite'];
+            $userType = $json['clientInfo']['userType'] ?? '';
+            $userId = $json['clientInfo']['userId'] ?? '';
+            $terms = $json['searchQueryParams']['inputFormTerms']['searchTerms'] ?? '';
+            $subsite = $json['subSite'] ?? '';
             $text = "The $userType user $userId searched for \"$terms\" on subsite $subsite.";
         } elseif ($action === 'Search') {
-            $terms = $json['filters']['textFilter'];
-            $geo = $json['filters']['geoFilter'];
+            $terms = $json['filters']['textFilter'] ?? '';
+            $geo = $json['filters']['geoFilter'] ?? '';
             $text = "Data discovery search with text \"$terms\"";
             if (!empty($geo)) {
                 $text .= " and used a map search";
             }
             $text .= '.';
         } elseif ($action === 'Mark as Remotely Hosted') {
-            $userId = $json['userId'];
-            $submissionId = $json['datasetSubmissionId'];
+            $userId = $json['userId'] ?? '';
+            $submissionId = $json['datasetSubmissionId'] ?? '';
             $text = "User $userId set remotely hosted on submission id $submissionId";
         } elseif ($action === 'File Download') {
-            $userType = $json['userType'];
-            $userId = $json['userId'];
-            $udi = $json['udi'] ?? null;
+            $userType = $json['userType'] ?? '';
+            $userId = $json['userId'] ?? '';
+            $udi = $json['udi'] ?? '';
             $text = "The $userType user $userId downloaded a complete zip";
             if (!empty($udi)) {
                 $text .= " of dataset $udi";
@@ -235,10 +235,10 @@ class LogActionItem extends Entity
                 $text .= '.';
             }
         } elseif ($action === 'Single File Download') {
-            $userType = $json['userType'];
-            $userId = $json['userId'];
-            $filename = $json['filename'];
-            $udi = $json['udi'] ?? null;
+            $userType = $json['userType'] ?? '';
+            $userId = $json['userId'] ?? '';
+            $filename = $json['filename'] ?? '';
+            $udi = $json['udi'] ?? '';
              $text = "The $userType user $userId downloaded the single file $filename";
             if (!empty($udi)) {
                 $text .= " from dataset $udi";
@@ -246,13 +246,13 @@ class LogActionItem extends Entity
                 $text .= '.';
             }
         } elseif ($action === 'Dataset Deletion') {
-            $udi = $json['UDI'];
-            $user = $json['userId'];
+            $udi = $json['UDI'] ?? '';
+            $user = $json['userId'] ?? '';
             $text = "$user deleted dataset $udi.";
         } elseif ($action === 'Restriction Change') {
-            $userId = $json['userId'];
-            $from = $json['previousRestriction'];
-            $to = $json['newRestriction'];
+            $userId = $json['userId'] ?? '';
+            $from = $json['previousRestriction'] ?? '';
+            $to = $json['newRestriction'] ?? '';
             $text = "$userId changed dataset restriction flag from $from to $to.";
         } else {
             $text = 'Warning: Unknown JSON. Extend getPayloadDetails method in LogActionItemCrudController class.';


### PR DESCRIPTION
It would be really nice to show UDI instead of Dataset ID in many cases, but I'm thinking this probably should be implemented as a front-end to API query to resolve into UDI...thoughts? It's functional enough now I think, but that would be nice to have.