### PR TITLE
fix-pobbles

### DIFF
--- a/templates/DatasetMonitoring/v2/researchGroups.html.twig
+++ b/templates/DatasetMonitoring/v2/researchGroups.html.twig
@@ -149,7 +149,7 @@
                                 </svg>
                             </td>
 
-                            {% if (loop.index % 80) == 0 %}
+                            {% if (loop.index % 68) == 0 %}
                         </tr>
                         <tr style="height: 12px">
                             {% endif %}


### PR DESCRIPTION
I counted and only 68 seem to fit in a line, so pobbles 69-80 were not being shown per line. As an alternative, we could shrink pobbles if we wanted a nice even number.