### PR TITLE
Update ESRI Leaflet configuration to enable world view customization

### DIFF
--- a/.env
+++ b/.env
@@ -115,5 +115,5 @@ WKHTMLTOIMAGE_PATH=/usr/local/bin/wkhtmltoimage
 
 ###> ESRI Leaflet ###
 ESRI_API_KEY='yourkeyhere'
-WORLD_VIEW_CODE='default' # 'default' or 'unitedStatesOfAmerica'
+#WORLD_VIEW_CODE='unitedStatesOfAmerica'
 ###< ESRI Leaflet ###


### PR DESCRIPTION
It seems that `default` is not longer a valid World View Code, so just leave it empty. That means comment it out in the `.env` file.