### PR TITLE
use DOI URL instead of doi://<doi>.

### DIFF
--- a/src/Util/DatasetCitationUtil.php
+++ b/src/Util/DatasetCitationUtil.php
@@ -36,7 +36,7 @@ class DatasetCitationUtil
         $citationString .= 'Distributed by: GRIIDC, Harte Research Institute, Texas A&M University–Corpus Christi. ';
 
         if ($doi instanceof DOI) {
-            $citationString .= 'doi:' . $doi->getDoi();
+            $citationString .= 'https://doi.org/' . $doi->getDoi();
         } else {
             $citationString .= "Available from: https://data.griidc.org/data/$udi";
         }


### PR DESCRIPTION
This also changes the "cite as:" section in the metadata product. If that is not desired, we'll have to add a parameter to the DOI utility to make the 'https://doi.org/' prefix an option.