### PR TITLE
Remove SFTP tab-select on review/submission. Add default of upload ta…

### DIFF
--- a/assets/static/js/dataset-submission.js
+++ b/assets/static/js/dataset-submission.js
@@ -237,12 +237,11 @@ $(function() {
         case "upload":
             fileTabs.tabs("option", "active", 0);
             break;
-        case "SFTP":
+        case "HTTP":
             fileTabs.tabs("option", "active", 1);
             break;
-        case "HTTP":
-            fileTabs.tabs("option", "active", 2);
-            break;
+        default:
+            fileTabs.tabs("option", "active", 0);
     }
 
     $("#pelagos-content button").button();

--- a/assets/static/js/datasetReview.js
+++ b/assets/static/js/datasetReview.js
@@ -267,12 +267,11 @@ $(document).ready(function(){
         case "upload":
             fileTabs.tabs("option", "active", 0);
             break;
-        case "SFTP":
+        case "HTTP":
             fileTabs.tabs("option", "active", 1);
             break;
-        case "HTTP":
-            fileTabs.tabs("option", "active", 2);
-            break;
+        default:
+            fileTabs.tabs("option", "active", 0);
     }
 
     var btnPrevious = $("#btn-previous");


### PR DESCRIPTION
This should prevent the "largefile" tab pre-selection issue. I corrected the tab selector so that "remotely hosted" pre-selects the correct tab. Previously, remotely hosted submissions were lighting up the last, large-files tab mistakingly.