### PR TITLE
fix: remove redundant jQuery require to avoid redeclaration with auto…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,9 @@ module.exports = {
     ],
     'import/no-cycle': 'off',
   },
+  globals: {
+    "$": "readonly"
+  },
   settings: {
     react: {
       version: 'detect', // React version. "detect" automatically picks the version you have installed.

--- a/assets/js/layout.js
+++ b/assets/js/layout.js
@@ -1,7 +1,5 @@
 import * as pelagosUI from './modules/pelagosUI';
 
-const $ = require('jquery');
-
 global.jQuery = $;
 global.$ = global.jQuery;
 global.pelagosUI = pelagosUI;

--- a/assets/js/main/app.js
+++ b/assets/js/main/app.js
@@ -9,8 +9,6 @@ import templateSwitch from '../vue/utils/template-switch';
 import Routing from '../../../vendor/friendsofsymfony/jsrouting-bundle/Resources/public/js/router.min';
 import GriidcMenu from '../react/components/GriidcMenu';
 
-const $ = require('jquery');
-
 global.jQuery = $;
 global.$ = global.jQuery;
 require('../../css/template.css');

--- a/assets/js/main/gomri.js
+++ b/assets/js/main/gomri.js
@@ -6,8 +6,6 @@ import '../../scss/gomri.scss';
 import templateSwitch from '../vue/utils/template-switch';
 import Routing from '../../../vendor/friendsofsymfony/jsrouting-bundle/Resources/public/js/router.min';
 
-const $ = require('jquery');
-
 global.jQuery = $;
 global.$ = global.jQuery;
 require('../../css/template.css');

--- a/assets/js/main/hri-app.js
+++ b/assets/js/main/hri-app.js
@@ -6,11 +6,8 @@ import 'bootstrap';
 import templateSwitch from '../vue/utils/template-switch';
 import Routing from '../../../vendor/friendsofsymfony/jsrouting-bundle/Resources/public/js/router.min';
 
-const $ = require('jquery');
-
 global.jQuery = $;
 global.$ = global.jQuery;
-
 require('../../css/template.css');
 require('../../css/superfish.css');
 require('../../css/pelagos-module.css');

--- a/assets/js/main/nas-app.js
+++ b/assets/js/main/nas-app.js
@@ -6,11 +6,8 @@ import 'bootstrap';
 import templateSwitch from '../vue/utils/template-switch';
 import Routing from '../../../vendor/friendsofsymfony/jsrouting-bundle/Resources/public/js/router.min';
 
-const $ = require('jquery');
-
 global.jQuery = $;
 global.$ = global.jQuery;
-
 require('../../css/template.css');
 require('../../css/superfish.css');
 require('../../css/pelagos-module.css');


### PR DESCRIPTION
This fixes the issue with the JQuery re-declaration and the visibility needed so the CDN-based includes still see what they're expecting. This does not address the merge conflict in yarn.lock, which can now just be resolved by re-generating a new yarn.lock on this epic after merging this in.