### PR TITLE
Compare array values directly.

### DIFF
--- a/assets/js/modules/spatialWizard.js
+++ b/assets/js/modules/spatialWizard.js
@@ -332,8 +332,10 @@ export default class SpatialWizard {
 
         // if featureType is Polygon, add first coordinate pair to the end of the array to close the polygon
         if (featureType === 'Polygon') {
-          if (coordinatePairs[0] !== coordinatePairs[coordinatePairs.length - 1]) {
-            coordinatePairs.push(coordinatePairs[0]);
+          const first = coordinatePairs[0];
+          const last = coordinatePairs[coordinatePairs.length - 1];
+          if (first[0] !== last[0] || first[1] !== last[1]) {
+            coordinatePairs.push([...first]);
           }
           coordinatePairs = [coordinatePairs];
         }

--- a/assets/js/modules/spatialWizard.js
+++ b/assets/js/modules/spatialWizard.js
@@ -334,7 +334,7 @@ export default class SpatialWizard {
         if (featureType === 'Polygon') {
           const first = coordinatePairs[0];
           const last = coordinatePairs[coordinatePairs.length - 1];
-          if (first[0] !== last[0] || first[1] !== last[1]) {
+          if (first && last && (first[0] !== last[0] || first[1] !== last[1])) {
             coordinatePairs.push([...first]);
           }
           coordinatePairs = [coordinatePairs];


### PR DESCRIPTION
Bug - previously comparing 2 arrays (regardless of value) would always be false as they're different references, so !== was always true.  === and !== don't work the same way with arrays.