### PR TITLE
Misc/update deploy scripts

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,18 +1,5 @@
 #/bin/sh
 
-args=("$@")
-
-case ${args[0]} in
-DRUPALGRIIDC)
-    echo 'Setting Encore PublicPath to special pelagos-symfony path for drupal-coexistence'
-    export publicpath="/pelagos-symfony/build"
-    ;;
-*)
-    echo 'Setting Encore PublicPath to /build'
-    export publicpath="/build"
-    ;;
-esac
-
 # Stop MessageMQ
 bin/console messenger:stop-workers
 
@@ -43,5 +30,4 @@ bin/console doctrine:migrations:status
 bin/console fos:elastica:reset
 bin/console fos:elastica:populate
 
-#
 echo "Remember to start consumers with: sudo systemctl start pelagos-messengemq"

--- a/bin/quick-deploy
+++ b/bin/quick-deploy
@@ -1,0 +1,5 @@
+#/bin/sh
+
+composer install --no-dev --optimize-autoloader
+yarn run encore prod
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ Encore
   .setOutputPath('public/build/')
 
 // public path used by the web server to access the output path
-  .setPublicPath(process.env.publicpath ? process.env.publicpath : '/build')
+  .setPublicPath('/build')
 
 // only needed for CDN's or sub-directory deploy
   .setManifestKeyPrefix('build/')


### PR DESCRIPTION
bin/deploy takes forever, and if there's no good reason to reload elasticsearch, we should not be. Also, I removed the old drupal-related code we've not needed since the Drupal Divorce. 