### PR TITLE
Feature/pelagos 5719 move all boosts from es index to es queries

### DIFF
--- a/config/packages/fos_elastica.yaml
+++ b/config/packages/fos_elastica.yaml
@@ -17,7 +17,7 @@ fos_elastica:
                 finder: ~
             properties:
                 udi: ~
-                title: { boost: 3 }
+                title: ~
                 abstract: ~
                 availabilityStatus: ~
                 identifiedStatus: ~
@@ -42,16 +42,16 @@ fos_elastica:
                         datasetFileTransferStatus: ~
                         datasetFileSize: ~
                         restrictions: ~
-                        placeKeywords: { boost: 3 }
-                        themeKeywords: { boost: 3 }
+                        placeKeywords: ~
+                        themeKeywords: ~
                 doi:
                     type: 'nested'
                     properties:
-                        doi: { boost: 3 }
+                        doi: ~
                 publications:
                     type: 'nested'
                     properties:
-                        doi: { boost: 3 }
+                        doi: ~
                 geometry:
                     type: 'text'
                     property_path: false

--- a/src/Search/MultiSearch.php
+++ b/src/Search/MultiSearch.php
@@ -96,7 +96,32 @@ class MultiSearch
         $queryString = $searchOptions->getQueryString();
         $specifiedField = empty($searchOptions->getField()) ? [] : [$searchOptions->getField()];
 
-        $simpleQuery = new Query\SimpleQueryString($queryString, $specifiedField);
+        $simpleQuery = new Query\SimpleQueryString($queryString);
+
+        // Boosts have moved from index to the queries as index boosts are no longer supported since
+        // moving to Elasticsearch 8. This boosts title, Place/Theme keywords, & DOIs to 3x weight
+        // IFF a specific field isn't being queried. Boost only makes sense to for broad queries.
+        if (empty($specifiedField)) {
+            $simpleQuery->setFields([
+                'title^3',
+                'abstract',
+                'datasetSubmission.authors',
+                'datasetSubmission.themeKeywords^3',
+                'datasetSubmission.placeKeywords^3',
+                'doi.doi^3',
+                'publications.doi^3',
+                'creators',
+                'publisher',
+                'researchGroup.name',
+                'researchGroups.name',
+                'funders.name',
+            ]);
+        } else {
+            // If a field is specified used, add the field to the simpleQuery and don't use boosts. This
+            // is a narrow search.
+            $simpleQuery->setFields($specifiedField);
+        }
+
         $simpleQuery->setParam('flags', 'PHRASE|PREFIX|WHITESPACE');
         $simpleQuery->setDefaultOperator(Query\SimpleQueryString::OPERATOR_AND);
 

--- a/src/Util/DatasetIndex.php
+++ b/src/Util/DatasetIndex.php
@@ -119,10 +119,16 @@ class DatasetIndex
             if (!empty($text)) {
                 $datasetQuery = new Query\MultiMatch();
                 $datasetQuery->setQuery($text);
+                // Boosts have moved from index to the queries as index boosts are no longer supported since
+                // moving to Elasticsearch 8. This boosts title, Place/Theme keywords, & DOIs to 3x weight.
                 $datasetQuery->setFields(
                     array(
-                        'title',
+                        'title^3',
                         'abstract',
+                        'datasetSubmission.placeKeywords^3',
+                        'datasetSubmission.themeKeywords^3',
+                        'doi.doi^3',
+                        'publications.doi^3'
                     )
                 );
                 $textQuery->addShould($datasetQuery);

--- a/src/Util/Search.php
+++ b/src/Util/Search.php
@@ -55,6 +55,11 @@ class Search
     public const ELASTIC_INDEX_MAPPING_THEME_KEYWORDS = 'datasetSubmission.themeKeywords';
 
     /**
+     * Elastic index mapping for place keywords.
+     */
+    public const ELASTIC_INDEX_MAPPING_PLACE_KEYWORDS = 'datasetSubmission.placeKeywords';
+
+    /**
      * Elastic index mapping for dataset DOI.
      */
     public const ELASTIC_INDEX_MAPPING_DOI = 'doi.doi';
@@ -82,9 +87,9 @@ class Search
     ];
 
     /**
-     * Index boost for Title, Authors, Theme Keywords.
+     * Search boost for Title, Authors, Theme, and Place Keywords.
      */
-    private const BOOST = '^2';
+    private const BOOST = '^3';
 
     /**
      * Default value for aggregation size to get all aggregation terms.
@@ -518,7 +523,7 @@ class Search
     }
 
     /**
-     * Get Bool query for fields.
+     * Get Bool query for fields. Add query boost for title, authors, place/theme keywords, & DOIs.
      *
      * @param string     $queryTerm           query term that needs to be searched upon
      * @param string     $specificField       query a specific field for data
@@ -531,6 +536,7 @@ class Search
                 self::ELASTIC_INDEX_MAPPING_TITLE . self::BOOST,
                 self::ELASTIC_INDEX_MAPPING_ABSTRACT,
                 self::ELASTIC_INDEX_MAPPING_THEME_KEYWORDS . self::BOOST,
+                self::ELASTIC_INDEX_MAPPING_PLACE_KEYWORDS . self::BOOST,
                 self::ELASTIC_INDEX_MAPPING_AUTHORS . self::BOOST,
             ];
         } else {

--- a/src/Util/Search.php
+++ b/src/Util/Search.php
@@ -89,7 +89,12 @@ class Search
     /**
      * Search boost for Title, Authors, Theme, and Place Keywords.
      */
-    private const BOOST = '^3';
+    private const BOOST = '^9'; // was previously boosted by 3 at index, and 3 here, so 9 is equivalent to previous boost.
+
+    /**
+     * Search boost for Authors.
+     */
+    private const AUTHOR_BOOST = '^3';
 
     /**
      * Default value for aggregation size to get all aggregation terms.
@@ -537,7 +542,7 @@ class Search
                 self::ELASTIC_INDEX_MAPPING_ABSTRACT,
                 self::ELASTIC_INDEX_MAPPING_THEME_KEYWORDS . self::BOOST,
                 self::ELASTIC_INDEX_MAPPING_PLACE_KEYWORDS . self::BOOST,
-                self::ELASTIC_INDEX_MAPPING_AUTHORS . self::BOOST,
+                self::ELASTIC_INDEX_MAPPING_AUTHORS . self::AUTHOR_BOOST,
             ];
         } else {
             $specificField = [$specificField];
@@ -808,6 +813,8 @@ class Search
         $pubDoiNestedQuery->setPath('publications');
         $pubDoiQuery = new Query\MatchPhrase();
         $pubDoiQuery->setFieldQuery(self::ELASTIC_INDEX_MAPPING_PUB_DOI, $queryTerm);
+        // Matching the boost to what we had with previous index boosts
+        $pubDoiQuery->setFieldBoost(self::ELASTIC_INDEX_MAPPING_PUB_DOI, 3);
         $pubDoiNestedQuery->setQuery($pubDoiQuery);
 
         return $pubDoiNestedQuery;


### PR DESCRIPTION
This ES7 backwards-compatible update migrates boosts to the Elasticsearch queries. We'll need this before we can switch to ES8.