### PR TITLE
We can update existing postcss 8, leaving the vue-2 bound 7.x ver unt…

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,13 @@
     },
     "license": "UNLICENSED",
     "private": true,
+    "resolutions": {
+        "postcss@^8.2.14": "^8.5.12",
+        "postcss@^8.4.14": "^8.5.12",
+        "postcss@^8.4.24": "^8.5.12",
+        "postcss@^8.4.33": "^8.5.12",
+        "postcss@^8.4.47": "^8.5.12"
+    },
     "scripts": {
         "dev-server": "encore dev-server",
         "dev": "encore dev",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8257,12 +8257,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.16":
+  version: 3.3.17
+  resolution: "nanoid@npm:3.3.17"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
   languageName: node
   linkType: hard
 
@@ -9377,14 +9377,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.14, postcss@npm:^8.4.14, postcss@npm:^8.4.24, postcss@npm:^8.4.33, postcss@npm:^8.4.47":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
+"postcss@npm:^8.5.12":
+  version: 8.5.25
+  resolution: "postcss@npm:8.5.25"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
+  checksum: 10c0/0a12c1e74b456c57122e81f684e02fd98ff4d57526f794d10c996df1147158808f5ae373ac82b988c8de6cbbaa82dbd7b13803b14f5dd3cf7cc6a42ccad5c9f2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…ouched

We could do this so the 8.x version we have is current, leaving only vue-locked version to itself to eventually go away with vue? This is all build-time only (7.x and 8.x) as user input doesn't touch it, so we're not vulnerable. 