### PR TITLE
Insure RHEL-9 systemd service compatability for pelagos-messengemq.

### DIFF
--- a/share/bash/control-pelagos-messagemq-consumer.sh
+++ b/share/bash/control-pelagos-messagemq-consumer.sh
@@ -24,7 +24,11 @@
 ###############################################################################
 
 # Get function from functions library
-. /etc/init.d/functions
+if [ -f /etc/init.d/functions ]; then
+    . /etc/init.d/functions
+elif [ -f /etc/rc.d/init.d/functions ]; then
+    . /etc/rc.d/init.d/functions
+fi
 
 prog="pelagos-messagemq-consumer-supervisor"
 
@@ -114,4 +118,8 @@ case "$1" in
         exit 1
 esac
 
-exit 0
+if $success ; then
+    exit 0
+else
+    exit 1
+fi

--- a/share/service-files/pelagos-messengemq.service
+++ b/share/service-files/pelagos-messengemq.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Control Pelagos Messagemq supervisord/consumer
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
proteus.tamucc.edu is RHEL-9 based, and we should update all our RHEL-8 systems to RHEL-9 as it's supported until 2032. Proteus is slated to replace griidc-dev (RHEL-8). For RHEL-9 compatibility, we needed to update our .service files accordingly. This will also work in RHEL-8. 